### PR TITLE
Add link to /docs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,6 +40,7 @@
           <ul class="nav navbar-nav navbar-right">
             <li><a href="/docs/about">About</a></li>
             <li><a href="/blog">Blog</a></li>
+            <li><a href="/docs">Docs</a></li>
             <li><a href="/docs/rules">Rules</a></li>
             <li><a href="/docs/developer-guide">Developer Guide</a></li>
             <li><a href="/docs/command-line-interface">Command Line</a></li>


### PR DESCRIPTION
I couldn't find any links on the site pointing to /docs, so I had to guess the url. Then I found a link there to the page I was actually looking for: /docs/configuring/

Not sure adding Docs is the best solution to the problem, but it would be nice if it was easier to find :)
