### PR TITLE
Add page.title to `<title>`

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="{{ site.description }}">
+{% if page.title != site.name %}
+  <title>{{ page.title }} - {{ site.name }}</title>
+{% else %}
   <title>{{ site.name }}</title>
+{% endif %}
   <link rel="stylesheet" href="/styles/main.936b04d2.css"/>
   <link rel="icon" href="/img/favicon.512x512.png">
   <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}/feed.xml">


### PR DESCRIPTION
Hi,
I consider need more information on page's `<title>`.

This pull request added page.title to `<title>`

Before : 

![before](http://take.ms/o7jwb)

After : 

![after](http://take.ms/3npzS)
