### PR TITLE
Revert "Chore: faraday@0.15.3 (work around netlify issue) (#624)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
-gem 'faraday', '0.15.3', group: :jekyll_plugins


### PR DESCRIPTION
refs https://github.com/eslint/website/issues/625

This reverts commit 8773fef25019eb3c43ade7ce5e08d57fee040aa8. Testing this out as suggested by https://github.com/eslint/website/issues/625#issuecomment-536374463.

Edit: Looks like it's fixed! 🎉 