### PR TITLE
Chore: fix badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/eslint/eslint.github.io.svg?branch=master)](https://travis-ci.org/eslint/eslint.github.io)
+[![Build Status](https://travis-ci.org/eslint/website.svg?branch=master)](https://travis-ci.org/eslint/website)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/cefb59aa-729a-4f8e-be36-b981fda399c0/deploy-status)](https://app.netlify.com/sites/eslint/deploys)
 
 # ESLint Web Site


### PR DESCRIPTION
The repository name has been changed before, which caused invalid badge URL. This PR fixes it.