### PR TITLE
Update: Add ECMA Version 11 in parser demo

### DIFF
--- a/src/js/parser/parser.config.js
+++ b/src/js/parser/parser.config.js
@@ -11,7 +11,8 @@ export default {
         7: false,
         8: false,
         9: false,
-        10: false
+        10: false,
+        11: false
     },
     sourceType: {
         script: false,


### PR DESCRIPTION
This PR adds `11` to the `ECMA Version` list in the parser demo.