### PR TITLE
Update: handle crashes and report invalid autofix in ESLint demo

### DIFF
--- a/src/js/demo/components/BugReport.jsx
+++ b/src/js/demo/components/BugReport.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export default function BugReport(props) {
+    return (
+        <div className="alert report-message-alert alert-danger">
+            <div>
+                {props.message}
+            </div>
+            <div>
+                Please submit a bug report at:
+            </div>
+            <div>
+                <a href="https://github.com/eslint/eslint/issues">https://github.com/eslint/eslint/issues</a>
+            </div>
+        </div>
+    );
+}

--- a/src/js/demo/components/Crash.jsx
+++ b/src/js/demo/components/Crash.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import BugReport from "./BugReport";
+
+export default function Crash(props) {
+    return (
+        <div>
+            <BugReport message="ESLint crashed!" />
+            <pre id="crashError">
+                {props.error.stack}
+            </pre>
+        </div>
+    );
+}


### PR DESCRIPTION
This PR adds two things to the ESLint online demo:

* Demo will now handle and show linter's runtime errors instead of crashing.
* Demo will now report invalid autofix (parsing errors only).

Test code for crashing:

```js
/* eslint no-implicit-coercion:error */

let x ="" + 1n;
```

![crash](https://user-images.githubusercontent.com/44349756/66521116-d0552a80-eaea-11e9-9929-7fb56ee3da04.png)

Test code for invalid autofix:

```js
/* eslint prefer-numeric-literals: ["error"] */

parseInt("11", 2)in foo
```

![autofix](https://user-images.githubusercontent.com/44349756/66521350-435ea100-eaeb-11e9-9c7b-58bfb0d5892b.png)
