### PR TITLE
Fix: deselect all doesn't deselect all checkboxes in ESLint demo

### DIFF
--- a/src/js/demo/components/RulesConfig.jsx
+++ b/src/js/demo/components/RulesConfig.jsx
@@ -33,7 +33,7 @@ function Rule(ref) {
 
 export default function RulesConfig(props) {
     function shouldBeChecked(rule) {
-        return props.config[rule] && props.config[rule] !== "off" && props.config[rule] !== 0;
+        return Boolean(props.config[rule]) && props.config[rule] !== "off" && props.config[rule] !== 0;
     }
 
     function handleChange(e, key) {


### PR DESCRIPTION
This might solve #626, seems that the problem was with setting `checked` to `undefined`.

I'm not 100% sure that the problem is fixed, but it looks okay in my browser. Would be good if someone else could test this, too.