### PR TITLE
Update: Add Configuration.shouldComponentUpdate

### DIFF
--- a/src/js/demo/components/Configuration.jsx
+++ b/src/js/demo/components/Configuration.jsx
@@ -30,6 +30,11 @@ export default class Configuration extends Component {
         }
     }
 
+    shouldComponentUpdate(nextProps, nextState) {
+        return this.state.showingConfig !== nextState.showingConfig ||
+            JSON.stringify(this.props.options) !== JSON.stringify(nextProps.options);
+    }
+
     render() {
         return (
             <div className="panel-group" id="accordion">


### PR DESCRIPTION
This PR improves UI responsiveness while working in the editor and while switching between Messages/Fixed code tabs when the Rules Configuration panel is open. This method prevents the configuration panel to re-render on each change.

In general, using `JSON.stringify` isn't recommendable in `shouldComponentUpdate`, but it looks safe in this particular case, and the component is already doing that on the same object to allow users to download configuration.

Also, using `shouldComponentUpdate` at all wasn't recommendable before, but as far as I know it isn't the case anymore.