### PR TITLE
Chore: start:docker npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,37 @@ Please note that all HTML documentation is split between this repository and the
 
 ## Developer Setup
 
-This repository runs on GitHub pages through Jekyll. To setup a local environment, please follow the [GitHub instruction](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/) (be sure to follow the instructions for your platform).
+This website is built with [Jekyll](https://jekyllrb.com) and is hosted on [Netlify](https://www.netlify.com).
 
-Once you have setup a local environment, you can run a copy of the website locally using this command:
+### Local development
 
-```
+To set up a local development environment, please follow [GitHub's instructions](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll) (be sure to follow the instructions for your platform).
+
+Once you have set up a local environment, you can run a copy of the website locally using this command:
+
+```sh
 $ npm start
 ```
 
-To run webpack to bundle the JavaScript and styles, you can run the following:
+### Development using Docker
+
+If you have [Docker](https://www.docker.com) installed, you can run the following:
+
+```sh
+$ npm run start:docker
+```
+
+This will run the following command, creating a temporary container that builds and serves the site and watches for local changes:
+
+```sh
+$ docker run --rm \
+    -v `pwd`:/srv/jekyll \
+    -p 4000:4000 \
+    -it jekyll/jekyll:3.8 \
+    jekyll serve -V --config _config.yml,_config.dev.yml
+```
+
+To run webpack to bundle the JavaScript and style assets, you can run the following:
 
 ```
 $ npm run start:webpack

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "npm run build:less && npm run build:webpack && npm run build:jekyll",
     "start:jekyll": "bundle exec jekyll serve --config _config.yml,_config.dev.yml",
     "start:webpack": "webpack -w --mode=development",
+    "start:docker": "npm run build:less && docker run --rm -v `pwd`:/srv/jekyll -p 4000:4000 -it jekyll/jekyll:3.8 jekyll serve -V --config _config.yml,_config.dev.yml",
     "start": "npm run build:less && npm run start:jekyll",
     "lint": "eslint --ext=.js,.jsx .",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
Adds a `start:docker` `npm` script for ease of development (no having to set up a Jekyll dev env :tada:!)  for those who have Docker installed. The current command removes the container after each run, but there are lots of things we can do to improve this in the future if we want.