### PR TITLE
Fix: Popover doesn't hide after checking the rule

### DIFF
--- a/src/js/demo/components/RulesConfig.jsx
+++ b/src/js/demo/components/RulesConfig.jsx
@@ -6,20 +6,10 @@ function Rule(ref) {
         ref.handleChange(e, ref.rule);
     }
 
-    function showPopover(e) {
-        e.currentTarget.Popover.show();
-    }
-
-    function hidePopover(e) {
-        e.currentTarget.Popover.hide();
-    }
-
     return (
         <div className="checkbox">
             <label
                 htmlFor={ref.rule}
-                onMouseEnter={showPopover}
-                onMouseLeave={hidePopover}
                 data-toggle="popover"
                 data-content={ref.docs.description}
                 title={ref.rule}


### PR DESCRIPTION
When one checks the rule's box to enable/disable the rule and doesn't move the mouse right away, the popover doesn't hide, so the screen might end up looking like this:

![image](https://user-images.githubusercontent.com/44349756/66688469-0d562400-ec87-11e9-90e2-a028eecf94da.png)

It's probably because the original checkbox (label) is being removed from the DOM after the click and replaced with a new one, so `onMouseLeave` doesn't happen.

This PR should fix this by removing the code that manually shows and hides popovers. The Popovers are initialized for all elements in `Configuration.jsx` and it seems to work well by itself.