### PR TITLE
Update: use PureComponent and React.memo in configuration components

### DIFF
--- a/src/js/demo/components/Configuration.jsx
+++ b/src/js/demo/components/Configuration.jsx
@@ -8,8 +8,10 @@ function initPopovers() {
     const popoverElements = document.querySelectorAll("[data-toggle=\"popover\"]");
 
     for (let i = 0; i < popoverElements.length; ++i) {
-        // eslint-disable-next-line no-new
-        new Popover(popoverElements[i]);
+        if (!popoverElements[i].Popover) {
+            // eslint-disable-next-line no-new
+            new Popover(popoverElements[i]);
+        }
     }
 }
 

--- a/src/js/demo/components/Configuration.jsx
+++ b/src/js/demo/components/Configuration.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import { Popover } from "bootstrap.native";
 import ParserOptions from "./ParserOptions";
 import Environments from "./Environments";
@@ -13,11 +13,14 @@ function initPopovers() {
     }
 }
 
-export default class Configuration extends Component {
+export default class Configuration extends PureComponent {
     constructor(props) {
         super(props);
         this.state = { showingConfig: false };
         this.toggleShowingConfig = this.toggleShowingConfig.bind(this);
+        this.handleParserOptionsUpdate = this.handleParserOptionsUpdate.bind(this);
+        this.handleEnvironmentsUpdate = this.handleEnvironmentsUpdate.bind(this);
+        this.handleRulesConfigUpdate = this.handleRulesConfigUpdate.bind(this);
     }
 
     toggleShowingConfig() {
@@ -28,6 +31,18 @@ export default class Configuration extends Component {
         if (this.state.showingConfig) {
             initPopovers();
         }
+    }
+
+    handleParserOptionsUpdate(parserOptions) {
+        this.props.onUpdate(Object.assign({}, this.props.options, { parserOptions }));
+    }
+
+    handleEnvironmentsUpdate(env) {
+        this.props.onUpdate(Object.assign({}, this.props.options, { env }));
+    }
+
+    handleRulesConfigUpdate(rules) {
+        this.props.onUpdate(Object.assign({}, this.props.options, { rules }));
     }
 
     render() {
@@ -51,32 +66,20 @@ export default class Configuration extends Component {
                             <div className="panel-body">
                                 <ParserOptions
                                     options={this.props.options.parserOptions}
-                                    onUpdate={
-                                        parserOptions => {
-                                            this.props.onUpdate(Object.assign({}, this.props.options, { parserOptions }));
-                                        }
-                                    }
+                                    onUpdate={this.handleParserOptionsUpdate}
                                 />
                                 <hr />
                                 <Environments
                                     env={this.props.options.env}
                                     envNames={this.props.envNames}
-                                    onUpdate={
-                                        env => {
-                                            this.props.onUpdate(Object.assign({}, this.props.options, { env }));
-                                        }
-                                    }
+                                    onUpdate={this.handleEnvironmentsUpdate}
                                 />
                                 <hr />
                                 <RulesConfig
                                     config={this.props.options.rules}
                                     ruleNames={this.props.ruleNames}
                                     docs={this.props.docs}
-                                    onUpdate={
-                                        rules => {
-                                            this.props.onUpdate(Object.assign({}, this.props.options, { rules }));
-                                        }
-                                    }
+                                    onUpdate={this.handleRulesConfigUpdate}
                                 />
                                 <hr />
                                 <a

--- a/src/js/demo/components/Environments.jsx
+++ b/src/js/demo/components/Environments.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import SelectAllCheckbox from "./SelectAllCheckbox";
 
-export default function Environments(props) {
+function Environments(props) {
     const columnLimit = 3;
     const rowLimit = Math.ceil(props.envNames.length / columnLimit);
 
@@ -73,3 +73,5 @@ export default function Environments(props) {
         </div>
     );
 }
+
+export default React.memo(Environments);

--- a/src/js/demo/components/ParserOptions.jsx
+++ b/src/js/demo/components/ParserOptions.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function ParserOptions(props) {
+function ParserOptions(props) {
     return (
         <div className="row">
             <div className="col-md-4">
@@ -72,3 +72,5 @@ export default function ParserOptions(props) {
         </div>
     );
 }
+
+export default React.memo(ParserOptions);

--- a/src/js/demo/components/Rule.jsx
+++ b/src/js/demo/components/Rule.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+function Rule(props) {
+    function handler(e) {
+        props.onChange(e, props.rule);
+    }
+
+    return (
+        <div className="checkbox">
+            <label
+                htmlFor={props.rule}
+                data-toggle="popover"
+                data-content={props.docs.description}
+                title={props.rule}
+            >
+                <input type="checkbox" checked={props.isChecked} id={props.rule} onChange={handler} />
+                {props.rule}
+            </label>
+        </div>
+    );
+}
+
+export default React.memo(Rule);

--- a/src/js/demo/components/RulesConfig.jsx
+++ b/src/js/demo/components/RulesConfig.jsx
@@ -1,92 +1,89 @@
-import React from "react";
+import React, { PureComponent } from "react";
 import SelectAllCheckbox from "./SelectAllCheckbox";
+import Rule from "./Rule";
 
-function Rule(ref) {
-    function handler(e) {
-        ref.handleChange(e, ref.rule);
+export default class RulesConfig extends PureComponent {
+    constructor(props) {
+        super(props);
+        this.handleSingleChange = this.handleSingleChange.bind(this);
+        this.handleSelectAll = this.handleSelectAll.bind(this);
+        this.handleDeselectAll = this.handleDeselectAll.bind(this);
     }
 
-    return (
-        <div className="checkbox">
-            <label
-                htmlFor={ref.rule}
-                data-toggle="popover"
-                data-content={ref.docs.description}
-                title={ref.rule}
-            >
-                <input type="checkbox" checked={ref.isChecked} id={ref.rule} onChange={handler} />
-                {ref.rule}
-            </label>
-        </div>
-    );
-}
-
-export default function RulesConfig(props) {
-    function shouldBeChecked(rule) {
-        return Boolean(props.config[rule]) && props.config[rule] !== "off" && props.config[rule] !== 0;
+    shouldBeChecked(rule) {
+        return Boolean(this.props.config[rule]) && this.props.config[rule] !== "off" && this.props.config[rule] !== 0;
     }
 
-    function handleChange(e, key) {
-        const updatedConfig = Object.assign({}, props.config);
+    handleSingleChange(e, key) {
+        const updatedConfig = Object.assign({}, this.props.config);
 
         if (e.target.checked) {
             updatedConfig[key] = 2;
         } else {
             delete updatedConfig[key];
         }
-        props.onUpdate(updatedConfig);
+        this.props.onUpdate(updatedConfig);
     }
 
-    function getRow(i) {
-        const limit = Math.ceil(props.ruleNames.length / 3);
+    handleSelectAll() {
+        this.props.onUpdate(this.props.ruleNames.reduce((updatedConfig, ruleName) => {
+            updatedConfig[ruleName] = 2;
+            return updatedConfig;
+        }, {}));
+    }
+
+    handleDeselectAll() {
+        this.props.onUpdate({});
+    }
+
+    getRow(i) {
+        const limit = Math.ceil(this.props.ruleNames.length / 3);
         const start = limit * i;
 
         return Array(limit).fill("").map((item, index) => {
-            const rule = props.ruleNames[start + index];
+            const rule = this.props.ruleNames[start + index];
 
-            return rule && <Rule key={rule} rule={rule} docs={props.docs[rule].docs} isChecked={shouldBeChecked(rule)} handleChange={handleChange} />;
+            return rule &&
+                <Rule
+                    key={rule}
+                    rule={rule}
+                    docs={this.props.docs[rule].docs}
+                    isChecked={this.shouldBeChecked(rule)}
+                    onChange={this.handleSingleChange}
+                />;
         });
     }
 
-    function renderRules() {
+    renderRules() {
         return [0, 1, 2].map(i => (
             <div className="col-md-4" key={i}>
-                {getRow(i)}
+                {this.getRow(i)}
             </div>
         ));
     }
 
-    return (
-        <div className="row rules">
-            <div className="container">
-                <div className="row"><div className="col-md-12"><h3>Rules</h3></div></div>
-                <div className="checkbox">
-                    <label htmlFor="select-all-rules">
-                        <SelectAllCheckbox
-                            id="select-all-rules"
-                            selectedCount={
-                                props.ruleNames.filter(ruleName => props.config[ruleName] && props.config[ruleName] !== "off").length
-                            }
-                            totalCount={props.ruleNames.length}
-                            onSelectAll={
-                                function() {
-                                    props.onUpdate(props.ruleNames.reduce((updatedConfig, ruleName) => {
-                                        updatedConfig[ruleName] = 2;
-                                        return updatedConfig;
-                                    }, {}));
+    render() {
+        return (
+            <div className="row rules">
+                <div className="container">
+                    <div className="row"><div className="col-md-12"><h3>Rules</h3></div></div>
+                    <div className="checkbox">
+                        <label htmlFor="select-all-rules">
+                            <SelectAllCheckbox
+                                id="select-all-rules"
+                                selectedCount={
+                                    this.props.ruleNames.filter(ruleName => this.props.config[ruleName] && this.props.config[ruleName] !== "off").length
                                 }
-                            }
-                            onDeselectAll={
-                                function() {
-                                    props.onUpdate({});
-                                }
-                            }
-                        />
-                        {" "}Enable all rules
-                    </label>
+                                totalCount={this.props.ruleNames.length}
+                                onSelectAll={this.handleSelectAll}
+                                onDeselectAll={this.handleDeselectAll}
+                            />
+                            {" "}Enable all rules
+                        </label>
+                    </div>
+                    <div className="row">{this.renderRules()}</div>
                 </div>
-                <div className="row">{renderRules()}</div>
             </div>
-        </div>
-    );
+        );
+    }
 }


### PR DESCRIPTION
This PR improves UI responsiveness by using `React.PureComponent` and `React.memo` in the configuration components.

Currently, the demo is re-rendering everything (editor, messages, envs, rules...)  on any change anywhere.

After this change, demo will re-render only what needs to be rendered again. That is:

* Editor, messages/fixed code - always.
* Parser options - only when there is a change in that section.
* Environments - only when there is a change in that section.
* Rules - only when there is a change in that section.

Additionally, when a rule is selected/deselected, only that checkbox will be rendered again. It's observable in React DevTools profiler. This is the only change that required some work - to convert `RulesConfig` to class in order to always pass the same callback reference to child Rule components (I'm not sure is it somehow possible to do this with functional components and hooks).

This isn't a big change overall because all components were already de facto pure. The helpers are just shallow comparing new and previous props and state and that works well thanks to the way the components were already implemented.