### PR TITLE
Fix: controlled to uncontrolled inputs warning (fixes #636)

### DIFF
--- a/src/js/demo/components/Environments.jsx
+++ b/src/js/demo/components/Environments.jsx
@@ -48,7 +48,7 @@ function Environments(props) {
                                             <label htmlFor={envName}>
                                                 <input
                                                     type="checkbox"
-                                                    checked={props.env[envName]}
+                                                    checked={!!props.env[envName]}
                                                     id={envName}
                                                     onChange={
                                                         function(event) {

--- a/src/js/demo/components/ParserOptions.jsx
+++ b/src/js/demo/components/ParserOptions.jsx
@@ -46,7 +46,7 @@ function ParserOptions(props) {
                                 <label htmlFor={ecmaFeature}>
                                     <input
                                         type="checkbox"
-                                        checked={props.options.ecmaFeatures[ecmaFeature]}
+                                        checked={!!props.options.ecmaFeatures[ecmaFeature]}
                                         className="option-checkbox"
                                         id={ecmaFeature}
                                         onChange={


### PR DESCRIPTION
This warning is currently occurring because these two values can initially be `undefined`, making React treat it as an uncontrolled input. When the value is changed, it then switches to a boolean, causing it to be a controlled input and the warning to appear.