### PR TITLE
Fix: recommended rules crash

### DIFF
--- a/src/js/demo/components/App.jsx
+++ b/src/js/demo/components/App.jsx
@@ -77,7 +77,7 @@ export default class App extends Component {
                         sourceType: "script",
                         ecmaFeatures: {}
                     },
-                    rules: rules.reduce((result, rule, ruleId) => {
+                    rules: [...rules.entries()].reduce((result, [ruleId, rule]) => {
                         if (rule.meta.docs.recommended) {
                             result[ruleId] = 2;
                         }


### PR DESCRIPTION
Fixes ESLint Demo as it's currently broken (when opened without configuration in URL or local storage).

Hot to reproduce: clear cache and open demo.