### PR TITLE
Update: Add sidebar to blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,11 +1,30 @@
 {% include header.html %}
 {% include menu.html %}
-<main class="blog">
-  <article class="container">
-    {{ content }}
-    <footer>
-      <p class="text-center">ESLint depends on the support of individuals and companies. <a class="btn btn-default" href="https://opencollective.com/eslint">Become a Sponsor</a></p>
-    </footer>
-  </article>
-</main>
+<div class="container">
+  <div class="row">
+    <div class="col-md-8">
+      <main class="blog">
+        <article>
+          {{ content }}
+          <footer>
+            <p class="text-center">ESLint depends on the support of individuals and companies. <a class="btn btn-default" href="https://opencollective.com/eslint">Become a Sponsor</a></p>
+          </footer>
+        </article>
+      </main>
+    </div>
+    <div class="col-md-4 hidden-xs hidden-sm">
+      <h2>Recent Posts</h2>
+      <ul class="posts">
+        {% for post in site.posts limit: 25 %}
+          {% if post.url != page.url %}
+            <li class="{{ post.popular }} {{ post.new }}">
+              <a href="{{ post.url }}">{{ post.title }}</a><br>
+              <span class="date">{{ post.date | date: "%-d %B %Y" }}</span>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
 {% include footer.html %}

--- a/_pages/blog.html
+++ b/_pages/blog.html
@@ -1,6 +1,6 @@
 ---
 title: ESLint Blog
-layout: post
+layout: doc
 permalink: /blog
 edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/blog.html
 ---


### PR DESCRIPTION
This adds a sidebar with recent posts to each blog post on medium-sized screens and up. I wanted an easy way to look across a bunch of posts without needing to navigate back to the index. The sidebar disappears on smaller screens.

![Screen Shot 2019-11-06 at 11 57 44](https://user-images.githubusercontent.com/38546/68333500-79ad2300-008d-11ea-8a4b-3fc241f86b30.png)
