### PR TITLE
Update: Add sponsor count and donation totals to homepage

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -21,11 +21,23 @@ homepage: true
 </div>
 
 <hr class="hr-near-below">
+{% assign tiers = "gold,silver,bronze,backers" | split: "," %}
+{% assign monthlyTotal = 0 %}
+{% assign supportersCount = 0 %}
+{% for tier in tiers %}
+    {% if site.data.sponsors[tier].size > 0 %}
+        {% for sponsor in site.data.sponsors[tier] %}
+            {% assign supportersCount = supportersCount | plus: 1 %}
+            {% assign monthlyTotal = monthlyTotal | plus: sponsor.monthlyDonation %}
+        {% endfor %}
+    {% endif %}
+{% endfor %}
+{% assign monthlyTotal = monthlyTotal | divided_by: 100 %}
 
 <div class="row">
   <div class="col-sm-12">
     <h2 class="text-center">Sponsors</h2>
-    <p class="text-center">The following companies, organizations, and individuals support ESLint's ongoing maintenance and development.</p>
+    <p class="text-center">{{ supportersCount }} companies, organizations, and individuals are currently contributing <b>${{ monthlyTotal }}</b> each month to support ESLint's ongoing maintenance and development.</p>
     {% assign tiers = "gold,silver,bronze" | split: "," %}
     {% for tier in tiers %}
         {% if site.data.sponsors[tier].size > 0 %}


### PR DESCRIPTION
This adds a count of our total contributors and monthly donations to the homepage. I think this is useful because Open Collective, for some reason, doesn't have this info easily available (I end up calculating it by hand every time). 
![Screen Shot 2019-11-14 at 10 24 22](https://user-images.githubusercontent.com/38546/68885118-64f21000-06c9-11ea-8b21-e8672448ecca.png)
