### PR TITLE
Revert "Update: Pull GitHub Sponsors donation data (fixes #647)"

### DIFF
--- a/_data/sponsors.json
+++ b/_data/sponsors.json
@@ -5,45 +5,35 @@
             "url": "https://www.shopify.com",
             "image": "https://images.opencollective.com/shopify/eeb91aa/logo.png",
             "monthlyDonation": 100000,
-            "totalDonations": 700000,
-            "source": "opencollective",
-            "tier": "gold-sponsor"
+            "totalDonations": 700000
         },
         {
             "name": "Salesforce",
             "url": "http://engineering.salesforce.com",
             "image": "https://images.opencollective.com/salesforce/ca8f997/logo.png",
             "monthlyDonation": 100000,
-            "totalDonations": 801500,
-            "source": "opencollective",
-            "tier": "gold-sponsor"
+            "totalDonations": 801500
         },
         {
             "name": "Badoo",
             "url": "https://badoo.com/team?utm_source=eslint",
             "image": "https://images.opencollective.com/badoo/2826a3b/logo.png",
             "monthlyDonation": 100000,
-            "totalDonations": 1000000,
-            "source": "opencollective",
-            "tier": "gold-sponsor"
+            "totalDonations": 1000000
         },
         {
             "name": "Airbnb",
             "url": "https://www.airbnb.com/",
             "image": "https://images.opencollective.com/airbnb/d327d66/logo.png",
             "monthlyDonation": 100000,
-            "totalDonations": 1001000,
-            "source": "opencollective",
-            "tier": "gold-sponsor"
+            "totalDonations": 1001000
         },
         {
             "name": "Facebook Open Source",
             "url": "https://opensource.facebook.com",
             "image": "https://images.opencollective.com/fbopensource/fbb8a5b/logo.png",
             "monthlyDonation": 100000,
-            "totalDonations": 1000000,
-            "source": "opencollective",
-            "tier": "gold-sponsor"
+            "totalDonations": 1000000
         }
     ],
     "silver": [
@@ -52,137 +42,107 @@
             "url": "https://www.ampproject.org/",
             "image": "https://images.opencollective.com/amp/c8a3b25/logo.png",
             "monthlyDonation": 50000,
-            "totalDonations": 500000,
-            "source": "opencollective",
-            "tier": "silver-sponsor"
+            "totalDonations": 500000
         }
     ],
     "bronze": [
+        {
+            "name": "clay",
+            "url": "https://clay.global",
+            "image": "https://images.opencollective.com/clayglobal/2468f34/logo.png",
+            "monthlyDonation": 20000,
+            "totalDonations": 140000
+        },
         {
             "name": "Bugsnag Stability Monitoring",
             "url": "https://www.bugsnag.com/platforms?utm_source=Open Collective&utm_medium=Website&utm_content=open-source&utm_campaign=2019-community&utm_term=",
             "image": "https://images.opencollective.com/bugsnag-stability-monitoring/c2cef36/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 20000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
-        },
-        {
-            "name": "Crosswordsolver",
-            "url": "https://www.crosswordsolver.com",
-            "image": "https://images.opencollective.com/crosswordsolver/d4481d6/logo.png",
-            "monthlyDonation": 20000,
-            "totalDonations": 20000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 20000
         },
         {
             "name": "Codacy",
             "url": "https://www.codacy.com/?utm_source=eslint&utm_medium=cpm&utm_campaign=eslint-sponsorship",
             "image": "https://images.opencollective.com/codacy/ed22716/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 40000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 40000
         },
         {
             "name": "Mixpanel",
             "url": "https://mixpanel.com",
             "image": "https://images.opencollective.com/mixpanel/cd682f7/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 60000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 60000
         },
         {
             "name": "VPS Server",
             "url": "https://www.vpsserver.com",
             "image": "https://images.opencollective.com/vpsservercom/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 80000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 80000
         },
         {
             "name": "Free Icons by Icons8",
             "url": "https://icons8.com",
             "image": "https://images.opencollective.com/icons8/0b37d14/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 80000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 80000
         },
         {
             "name": "UI UX Design Agencies",
             "url": "https://uxplanet.org/top-ui-ux-design-agencies-user-experience-firms-8c54697e290",
             "image": "https://images.opencollective.com/ui-ux-design-agencies/cae5dfe/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 80000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 80000
         },
         {
-            "name": "clay",
-            "url": "https://clay.global",
-            "image": "https://images.opencollective.com/clayglobal/2468f34/logo.png",
+            "name": "Crosswordsolver",
+            "url": "https://www.crosswordsolver.com",
+            "image": "https://images.opencollective.com/crosswordsolver/d4481d6/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 140000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 20000
         },
         {
             "name": "Discord",
             "url": "https://discordapp.com",
             "image": "https://images.opencollective.com/discordapp/7e3d9a9/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 140000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 140000
         },
         {
             "name": "ThemeIsle",
             "url": "https://themeisle.com",
             "image": "https://images.opencollective.com/themeisle/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 160000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 160000
         },
         {
             "name": "TekHattan",
             "url": "https://tekhattan.com",
             "image": "https://images.opencollective.com/tekhattan/bc73c28/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 160000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 160000
         },
         {
             "name": "Marfeel",
             "url": "https://www.marfeel.com/",
             "image": "https://images.opencollective.com/marfeel/4b88e30/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 160000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 160000
         },
         {
             "name": "Fire Stick Tricks",
             "url": "http://www.firesticktricks.com",
             "image": "https://images.opencollective.com/fire-stick-tricks/b8fbe2c/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 160000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 160000
         },
         {
             "name": "JSHeroes ",
             "url": "https://jsheroes.io/",
             "image": "https://images.opencollective.com/jsheroes1/9fedf0b/logo.png",
             "monthlyDonation": 20000,
-            "totalDonations": 180000,
-            "source": "opencollective",
-            "tier": "bronze-sponsor"
+            "totalDonations": 180000
         }
     ],
     "backers": [
@@ -191,443 +151,301 @@
             "url": "https://yannick.cr",
             "image": "https://images.opencollective.com/yannickcr/765f06f/avatar.png",
             "monthlyDonation": 10000,
-            "totalDonations": 50000,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 50000
         },
         {
             "name": "Eventbot",
             "url": "https://geteventbot.com/",
             "image": "https://images.opencollective.com/geteventbot1/446b860/logo.png",
             "monthlyDonation": 3000,
-            "totalDonations": 15000,
-            "source": "opencollective",
-            "tier": null
+            "totalDonations": 15000
         },
         {
             "name": "Sebastian Software GmbH",
             "url": "http://sebastian-software.de/",
             "image": "https://images.opencollective.com/sebastiansoft/74395cd/logo.png",
             "monthlyDonation": 2500,
-            "totalDonations": 22500,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 22500
         },
         {
             "name": "Neovation Learning Solutions",
             "url": "https://www.neovation.com",
             "image": "https://images.opencollective.com/neovationcorp/30d1cf7/logo.png",
             "monthlyDonation": 2500,
-            "totalDonations": 25000,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 25000
         },
         {
             "name": "Ed Bentley",
             "url": "https://twitter.com/ed_s_bentley",
             "image": "https://images.opencollective.com/edward-bentley/avatar.png",
             "monthlyDonation": 2000,
-            "totalDonations": 12000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Ben Truyman",
-            "url": "https://github.com/bentruyman",
-            "image": "https://images.opencollective.com/bentruyman/9dc2d16/avatar.png",
-            "monthlyDonation": 1000,
-            "totalDonations": 1000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Patrick",
-            "url": "https://twitter.com/PatrickMWalther",
-            "image": "https://images.opencollective.com/patrick1/a9f87be/avatar.png",
-            "monthlyDonation": 1000,
-            "totalDonations": 1000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Moxio",
-            "url": "https://moxio.com",
-            "image": "https://images.opencollective.com/moxio/9fa53c1/logo.png",
-            "monthlyDonation": 1000,
-            "totalDonations": 21000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Kevin Partington",
-            "url": null,
-            "image": "https://images.opencollective.com/kevin-partington/54f2124/avatar.png",
-            "monthlyDonation": 1000,
-            "totalDonations": 6000,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 12000
         },
         {
             "name": "Benjamin Piouffle",
             "url": "https://benjamin.piouffle.com",
             "image": "https://images.opencollective.com/betree/6c68f43/avatar.png",
             "monthlyDonation": 1000,
-            "totalDonations": 9600,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 9600
         },
         {
-            "name": "Oliver Sieweke",
+            "name": "Patrick",
+            "url": "https://twitter.com/PatrickMWalther",
+            "image": "https://images.opencollective.com/patrick1/a9f87be/avatar.png",
+            "monthlyDonation": 1000,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Kevin Partington",
             "url": null,
-            "image": "https://images.opencollective.com/oliver-sieweke/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 2000,
-            "source": "opencollective",
-            "tier": "backer"
+            "image": "https://images.opencollective.com/kevin-partington/54f2124/avatar.png",
+            "monthlyDonation": 1000,
+            "totalDonations": 6000
         },
         {
-            "name": "0x Tracker",
-            "url": "https://0xtracker.com",
-            "image": "https://images.opencollective.com/0xtracker/b6f999b/logo.png",
-            "monthlyDonation": 500,
-            "totalDonations": 1500,
-            "source": "opencollective",
-            "tier": "backer"
+            "name": "Ben Truyman",
+            "url": "https://github.com/bentruyman",
+            "image": "https://images.opencollective.com/bentruyman/9dc2d16/avatar.png",
+            "monthlyDonation": 1000,
+            "totalDonations": 1000
         },
         {
-            "name": "Matter",
-            "url": "https://matterapp.com",
-            "image": "https://images.opencollective.com/matter_hq/ac0a719/logo.png",
-            "monthlyDonation": 500,
-            "totalDonations": 2000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Jack Cross",
-            "url": null,
-            "image": "https://images.opencollective.com/jack-cross/7b02eda/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 2500,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "James Sherwood-Jones",
-            "url": null,
-            "image": "https://images.opencollective.com/james-sherwood-jones/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 2500,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Eliseu Monar dos Santos",
-            "url": "https://medium.com/@eliseumds",
-            "image": "https://images.opencollective.com/eliseu/f4e6dad/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 2500,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Martin Desrumaux",
-            "url": null,
-            "image": "https://images.opencollective.com/martin-desrumaux/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 3000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "verdaccio",
-            "url": "https://verdaccio.org/",
-            "image": "https://images.opencollective.com/verdaccio/2d6ef61/logo.png",
-            "monthlyDonation": 500,
-            "totalDonations": 3000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Alexandre Morgaut",
-            "url": "https://www.quora.com/profile/Alexandre-Morgaut",
-            "image": "https://images.opencollective.com/alexandre-morgaut/6e3c8d4/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 4000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Jb Landry",
-            "url": "https://jblandry.info",
-            "image": "https://images.opencollective.com/jblandry/e968bf5/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 4000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Ivan Miskovic",
-            "url": "https://twitter.com/ivanandsickle",
-            "image": "https://images.opencollective.com/ivanandsickle/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 4500,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Eric Lanehart",
-            "url": "http://pushred.co",
-            "image": "https://images.opencollective.com/pushred/506ad8d/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 4500,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "AJ Klein",
-            "url": "https://twitter.com/jumbleofideas",
-            "image": "https://images.opencollective.com/aj-klein/b63b472/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 4500,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Andrew Rota",
-            "url": "https://twitter.com/andrewrota",
-            "image": "https://images.opencollective.com/andrewrota/a124847/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 4500,
-            "source": "opencollective",
-            "tier": "backer"
+            "name": "Moxio",
+            "url": "https://moxio.com",
+            "image": "https://images.opencollective.com/moxio/9fa53c1/logo.png",
+            "monthlyDonation": 1000,
+            "totalDonations": 21000
         },
         {
             "name": "Third Iron",
             "url": "https://thirdiron.com",
             "image": "https://images.opencollective.com/third_iron/fa6ec4d/logo.png",
             "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Martin K.",
-            "url": "https://kluska.cz",
-            "image": "https://images.opencollective.com/martin-kluska/588a7ff/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Maisonette Inc",
-            "url": "https://www.maisonette.com",
-            "image": "https://images.opencollective.com/maisonetteworld/c170bfc/logo.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Dan Foley",
-            "url": "http://cantremember.com",
-            "image": "https://images.opencollective.com/cantremember/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Simon Korzun",
-            "url": "http://korzun.com",
-            "image": "https://images.opencollective.com/simon-korzun/cbdefdd/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Mariusz Nowak",
-            "url": "https://medikoo.com",
-            "image": "https://images.opencollective.com/medikoo/f16a7ea/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Chih-Hsuan Fan",
-            "url": "https://pymaster.tw",
-            "image": "https://images.opencollective.com/pc035860/8fed8ae/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Gavin Mogan",
-            "url": "https://www.gavinmogan.com",
-            "image": "https://images.opencollective.com/gavinmogan/305e987/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Thomas Hermann",
-            "url": null,
-            "image": "https://images.opencollective.com/novascreen/ef6acf0/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Matan Kushner",
-            "url": "http://matchai.me",
-            "image": "https://images.opencollective.com/matchai/e1d9969/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5500,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Kevin Lamping",
-            "url": "http://klamp.in",
-            "image": "https://images.opencollective.com/klamping/26de35c/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Nubz Ltd",
-            "url": "http://nubz.com",
-            "image": "https://images.opencollective.com/nubz/logo.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Alexey Raspopov",
-            "url": "https://alexeyraspopov.com",
-            "image": "https://images.opencollective.com/alexeyraspopov/d8c7a67/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
-        },
-        {
-            "name": "Joseph Percy",
-            "url": null,
-            "image": "https://images.opencollective.com/joseph-percy/avatar.png",
-            "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 5000
         },
         {
             "name": "Jordan Harband",
             "url": "https://twitter.com/LJHarb",
             "image": "https://images.opencollective.com/ljharb/b75a3f8/avatar.png",
             "monthlyDonation": 500,
-            "totalDonations": 5000,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 5000
         },
         {
-            "name": "Pelle Wessman",
-            "image": "https://avatars1.githubusercontent.com/u/34457?v=4",
-            "url": "http://kodfabrik.se/",
+            "name": "Eliseu Monar dos Santos",
+            "url": "https://medium.com/@eliseumds",
+            "image": "https://images.opencollective.com/eliseu/f4e6dad/avatar.png",
             "monthlyDonation": 500,
-            "source": "github",
-            "tier": "backer"
+            "totalDonations": 2500
         },
         {
-            "name": "Jordan Harband",
-            "image": "https://avatars1.githubusercontent.com/u/45469?v=4",
-            "url": "https://twitter.com/ljharb",
+            "name": "James Sherwood-Jones",
+            "url": null,
+            "image": "https://images.opencollective.com/james-sherwood-jones/avatar.png",
             "monthlyDonation": 500,
-            "source": "github",
-            "tier": "backer"
+            "totalDonations": 2500
         },
         {
-            "name": "Marais Rossouw",
-            "image": "https://avatars2.githubusercontent.com/u/599459?v=4",
-            "url": "https://marais.io/",
+            "name": "Jack Cross",
+            "url": null,
+            "image": "https://images.opencollective.com/jack-cross/7b02eda/avatar.png",
             "monthlyDonation": 500,
-            "source": "github",
-            "tier": "backer"
+            "totalDonations": 2500
         },
         {
-            "name": "Jonny Burger",
-            "image": "https://avatars2.githubusercontent.com/u/1629785?v=4",
-            "url": "https://jonny.io",
+            "name": "Martin Desrumaux",
+            "url": null,
+            "image": "https://images.opencollective.com/martin-desrumaux/avatar.png",
             "monthlyDonation": 500,
-            "source": "github",
-            "tier": "backer"
+            "totalDonations": 3000
         },
         {
-            "name": "Kelp",
-            "image": "https://avatars3.githubusercontent.com/u/1680868?v=4",
-            "url": "https://meetpet.org",
+            "name": "verdaccio",
+            "url": "https://verdaccio.org/",
+            "image": "https://images.opencollective.com/verdaccio/2d6ef61/logo.png",
             "monthlyDonation": 500,
-            "source": "github",
-            "tier": "backer"
+            "totalDonations": 3000
         },
         {
-            "name": "Ivan Demidov",
-            "image": "https://avatars0.githubusercontent.com/u/2789192?v=4",
-            "url": "https://twitter.com/Scrum_",
+            "name": "Matter",
+            "url": "https://matterapp.com",
+            "image": "https://images.opencollective.com/matter_hq/ac0a719/logo.png",
             "monthlyDonation": 500,
-            "source": "github",
-            "tier": "backer"
+            "totalDonations": 2000
         },
         {
-            "name": "Evan Hirsh",
-            "image": "https://avatars2.githubusercontent.com/u/4483135?v=4",
-            "url": "http://www.ehirsh.com",
+            "name": "Alexandre Morgaut",
+            "url": "https://www.quora.com/profile/Alexandre-Morgaut",
+            "image": "https://images.opencollective.com/alexandre-morgaut/6e3c8d4/avatar.png",
             "monthlyDonation": 500,
-            "source": "github",
-            "tier": "backer"
+            "totalDonations": 4000
+        },
+        {
+            "name": "Jb Landry",
+            "url": "https://jblandry.info",
+            "image": "https://images.opencollective.com/jblandry/e968bf5/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 4000
+        },
+        {
+            "name": "Ivan Miskovic",
+            "url": "https://twitter.com/ivanandsickle",
+            "image": "https://images.opencollective.com/ivanandsickle/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 4500
+        },
+        {
+            "name": "Oliver Sieweke",
+            "url": null,
+            "image": "https://images.opencollective.com/oliver-sieweke/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 2000
+        },
+        {
+            "name": "Eric Lanehart",
+            "url": "http://pushred.co",
+            "image": "https://images.opencollective.com/pushred/506ad8d/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 4500
+        },
+        {
+            "name": "0x Tracker",
+            "url": "https://0xtracker.com",
+            "image": "https://images.opencollective.com/0xtracker/b6f999b/logo.png",
+            "monthlyDonation": 500,
+            "totalDonations": 1500
+        },
+        {
+            "name": "AJ Klein",
+            "url": "https://twitter.com/jumbleofideas",
+            "image": "https://images.opencollective.com/aj-klein/b63b472/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 4500
+        },
+        {
+            "name": "Andrew Rota",
+            "url": "https://twitter.com/andrewrota",
+            "image": "https://images.opencollective.com/andrewrota/a124847/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 4500
+        },
+        {
+            "name": "Joseph Percy",
+            "url": null,
+            "image": "https://images.opencollective.com/joseph-percy/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Martin K.",
+            "url": "https://kluska.cz",
+            "image": "https://images.opencollective.com/martin-kluska/588a7ff/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Maisonette Inc",
+            "url": "https://www.maisonette.com",
+            "image": "https://images.opencollective.com/maisonetteworld/c170bfc/logo.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Dan Foley",
+            "url": "http://cantremember.com",
+            "image": "https://images.opencollective.com/cantremember/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Simon Korzun",
+            "url": "http://korzun.com",
+            "image": "https://images.opencollective.com/simon-korzun/cbdefdd/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Mariusz Nowak",
+            "url": "https://medikoo.com",
+            "image": "https://images.opencollective.com/medikoo/f16a7ea/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Chih-Hsuan Fan",
+            "url": "https://pymaster.tw",
+            "image": "https://images.opencollective.com/pc035860/8fed8ae/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Gavin Mogan",
+            "url": "https://www.gavinmogan.com",
+            "image": "https://images.opencollective.com/gavinmogan/305e987/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Thomas Hermann",
+            "url": null,
+            "image": "https://images.opencollective.com/novascreen/ef6acf0/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Matan Kushner",
+            "url": "http://matchai.me",
+            "image": "https://images.opencollective.com/matchai/e1d9969/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5500
+        },
+        {
+            "name": "Kevin Lamping",
+            "url": "http://klamp.in",
+            "image": "https://images.opencollective.com/klamping/26de35c/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Alexey Raspopov",
+            "url": "https://alexeyraspopov.com",
+            "image": "https://images.opencollective.com/alexeyraspopov/d8c7a67/avatar.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
+        },
+        {
+            "name": "Nubz Ltd",
+            "url": "http://nubz.com",
+            "image": "https://images.opencollective.com/nubz/logo.png",
+            "monthlyDonation": 500,
+            "totalDonations": 5000
         },
         {
             "name": "Kyle Smith",
             "url": "https://ksmith.io",
             "image": "https://images.opencollective.com/knksmith57/1b834b2/avatar.png",
             "monthlyDonation": 300,
-            "totalDonations": 1700,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 1700
         },
         {
             "name": "Will McAuliff",
             "url": "https://twitter.com/womcauliff",
             "image": "https://images.opencollective.com/womcauliff/2be6f36/avatar.png",
             "monthlyDonation": 300,
-            "totalDonations": 3700,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 3700
         },
         {
             "name": "Anton Alexandrenok",
             "url": "https://github.com/the-spyke",
             "image": "https://images.opencollective.com/antonalexandrenok/c561172/avatar.png",
             "monthlyDonation": 200,
-            "totalDonations": 200,
-            "source": "opencollective",
-            "tier": null
+            "totalDonations": 200
         },
         {
             "name": "qnyp",
             "url": "https://qnyp.com",
             "image": "https://images.opencollective.com/qnyp/4da3762/logo.png",
             "monthlyDonation": 200,
-            "totalDonations": 3200,
-            "source": "opencollective",
-            "tier": "backer"
+            "totalDonations": 3200
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -851,55 +851,6 @@
         "url-template": "^2.0.8"
       }
     },
-    "@octokit/graphql": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
-      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
-      "dev": true,
-      "requires": {
-        "@octokit/request": "^5.3.0",
-        "@octokit/types": "^2.0.0",
-        "universal-user-agent": "^4.0.0"
-      },
-      "dependencies": {
-        "@octokit/endpoint": {
-          "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
-          "integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
-          "dev": true,
-          "requires": {
-            "@octokit/types": "^2.0.0",
-            "is-plain-object": "^3.0.0",
-            "universal-user-agent": "^4.0.0"
-          }
-        },
-        "@octokit/request": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
-          "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
-          "dev": true,
-          "requires": {
-            "@octokit/endpoint": "^5.5.0",
-            "@octokit/request-error": "^1.0.1",
-            "@octokit/types": "^2.0.0",
-            "deprecation": "^2.0.0",
-            "is-plain-object": "^3.0.0",
-            "node-fetch": "^2.3.0",
-            "once": "^1.4.0",
-            "universal-user-agent": "^4.0.0"
-          }
-        },
-        "universal-user-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-          "dev": true,
-          "requires": {
-            "os-name": "^3.1.0"
-          }
-        }
-      }
-    },
     "@octokit/request": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-4.1.1.tgz",
@@ -945,21 +896,6 @@
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       }
-    },
-    "@octokit/types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.2.tgz",
-      "integrity": "sha512-StASIL2lgT3TRjxv17z9pAqbnI7HGu9DrJlg3sEBFfCLaMEqp+O3IQPUF6EZtQ4xkAu2ml6kMBBCtGxjvmtmuQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": ">= 8"
-      }
-    },
-    "@types/node": {
-      "version": "12.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-      "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==",
-      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -1404,7 +1340,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1672,7 +1608,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1709,7 +1645,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2220,7 +2156,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2233,7 +2169,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2447,7 +2383,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -2785,7 +2721,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-      "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -2793,8 +2728,7 @@
         "eslint-visitor-keys": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-          "dev": true
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
         }
       }
     },
@@ -4890,7 +4824,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -5740,7 +5674,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -6143,7 +6077,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
-    "@octokit/graphql": "^4.3.1",
     "@octokit/rest": "^16.28.2",
     "babel-loader": "^8.0.6",
     "core-js": "^3.1.4",


### PR DESCRIPTION
Reverts eslint/website#651

This temporarily reverts changes to sponsors script, since Github permissions are not set correctly right now, and because of this, it blocks fetching sponsor date from OpenCollective.