### PR TITLE
Chore: add analytics to sponsor links on home page

### DIFF
--- a/_pages/index.liquid
+++ b/_pages/index.liquid
@@ -46,7 +46,7 @@ homepage: true
               <h4 class="sponsor-heading text-center">{{ tier | capitalize }} Sponsors</h4>
               <div class="sponsor-tier text-center">
                   {% for sponsor in sponsors[tier] %}
-                    <a href="{{ sponsor.url }}" title="{{ sponsor.name }}" rel="noopener nofollow" target="_blank">
+                    <a class="sponsor-link" href="{{ sponsor.url }}" title="{{ sponsor.name }}" rel="noopener nofollow" target="_blank">
                       <div class="sponsor {{ tier }}-sponsor">
                         <img class="lazyload" data-src="{{ sponsor.image }}" alt="{{ sponsor.name }}">
                       </div>

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -53,3 +53,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 window.ga("create", "UA-60915033-1", "eslint.org");
 window.ga("send", "pageview");
+document.querySelectorAll(".sponsor-link").forEach(
+    el => el.addEventListener("click",
+        () => window.ga("send", "event", "Logos", "click", el.title || ""))
+);

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -55,5 +55,5 @@ window.ga("create", "UA-60915033-1", "eslint.org");
 window.ga("send", "pageview");
 document.querySelectorAll(".sponsor-link").forEach(
     el => el.addEventListener("click",
-        () => window.ga("send", "event", "Logos", "click", el.title || ""))
+        () => window.ga("send", "event", "Sponsor Link", "click", el.title || ""))
 );


### PR DESCRIPTION
Small PR adding some Google Analytics events to the sponsor links on our home page. I'm not seeing the events fire locally (I'm actually not seeing any analytics requests going out), and I'm assuming that's due to it the requests not originating at `eslint.org`. Would love confirmation though!