### PR TITLE
Fix: update 2019-12-20-eslint-v6.8.0-released.md to fix liquid parsing error

### DIFF
--- a/_posts/2019-12-20-eslint-v6.8.0-released.md
+++ b/_posts/2019-12-20-eslint-v6.8.0-released.md
@@ -57,7 +57,8 @@ We just pushed ESLint v6.8.0, which is a minor release upgrade of ESLint. This r
 * [`e3c570e`](https://github.com/eslint/eslint/commit/e3c570eaf3d1d44fb57bf42f1870887856e4c5a0) Docs: Add example for expression option ([#12694](https://github.com/eslint/eslint/issues/12694)) (Arnaud Barré)
 * [`6b774ef`](https://github.com/eslint/eslint/commit/6b774ef0d849ccf5c1127b25e1fe7c3e438d586b) Docs: Add spacing in comments for [no-console](/docs/rules/no-console) rule ([#12696](https://github.com/eslint/eslint/issues/12696)) (Nikki Nikkhoui)
 * [`ab912f0`](https://github.com/eslint/eslint/commit/ab912f0ef709a916ab9a27ea09d9d7adf046fb2d) Docs: 1tbs with allowSingleLine edge cases (refs [#12284](https://github.com/eslint/eslint/issues/12284)) ([#12314](https://github.com/eslint/eslint/issues/12314)) (Ari Kardasis)
-* [`e9cef99`](https://github.com/eslint/eslint/commit/e9cef99e6ebec1faefdb576ca597e81ae4f04afd) Docs: wrap {{}} in raw liquid tags to prevent interpolation ([#12643](https://github.com/eslint/eslint/issues/12643)) (Kai Cataldo)
+* [`e9cef99`](https://github.com/eslint/eslint/commit/e9cef99e6ebec1faefdb576ca597e81ae4f04afd) Docs: wrap 
+{% raw %}{{}}{% endraw %} in raw liquid tags to prevent interpolation ([#12643](https://github.com/eslint/eslint/issues/12643)) (Kai Cataldo)
 * [`e707453`](https://github.com/eslint/eslint/commit/e70745325ff9e085acc6843dd8bfae5550645d4f) Docs: Fix configuration example in [no-restricted-imports](/docs/rules/no-restricted-imports) (fixes [#11717](https://github.com/eslint/eslint/issues/11717)) ([#12638](https://github.com/eslint/eslint/issues/12638)) (Milos Djermanovic)
 
 


### PR DESCRIPTION
The site is currently failing to build and I think it's most likely due to the unescaped Liquid interpolation syntax.