### PR TITLE
Update: add es2017, es2020 on env names

### DIFF
--- a/src/js/demo/components/App.jsx
+++ b/src/js/demo/components/App.jsx
@@ -59,6 +59,8 @@ const ENV_NAMES = [
     "embertest",
     "webextensions",
     "es6",
+    "es2017",
+    "es2020",
     "greasemonkey"
 ];
 


### PR DESCRIPTION

I think there was a lack of environment preset(es2017, es2020) in the `Configuration List in demo page`. This PR is for adding es2017, es2020 on the list.

* before
<img width="350" alt="스크린샷 2020-01-01 오후 7 51 37" src="https://user-images.githubusercontent.com/41323220/71640598-3e675300-2cd0-11ea-906a-32c24173a99e.png">

* After
<img width="350" alt="스크린샷 2020-01-01 오후 7 53 18" src="https://user-images.githubusercontent.com/41323220/71640608-766e9600-2cd0-11ea-9df0-174dc2e48e7b.png">

