### PR TITLE
Update: open demo rule links in new tab

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
                 }
             },
             rules: {
+                "react/jsx-no-target-blank": "error",
 
                 // Disable rules that the codebase doesn't currently follow.
                 // It might be a good idea to enable these in the future.

--- a/src/js/demo/components/Message.jsx
+++ b/src/js/demo/components/Message.jsx
@@ -26,7 +26,14 @@ export default function Message(props) {
             {
                 !props.value.fatal && [
                     " (",
-                    <a key="ruleLink" href={`https://eslint.org/docs/rules/${props.value.ruleId}`}>{props.value.ruleId}</a>,
+                    <a
+                        key="ruleLink"
+                        href={`https://eslint.org/docs/rules/${props.value.ruleId}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {props.value.ruleId}
+                    </a>,
                     ")"
                 ]
             }


### PR DESCRIPTION
I noticed that the links in the demo errors open in the same tab, navigating away from eslint.org. This PR adds a `target="_blank"` attribute to those links to open them in a new tab.

<img width="435" alt="Screen Shot 2020-01-15 at 10 45 59 PM" src="https://user-images.githubusercontent.com/7041728/72491710-d2fda500-37e8-11ea-9b9f-9b3521b65ed4.png">
