### PR TITLE
Chore: install demo deps during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
     "node": ">=12.0.0"
   },
   "scripts": {
+    "install:demo": "cd src/js/demo && npm install --no-package-lock",
     "build:eleventy": "eleventy --quiet",
     "build:webpack": "webpack --mode=production",
     "build:less": "lessc src/styles/main.less _site/assets/styles/main.css --clean-css --source-map=_site/assets/styles/main.css.map",
-    "build": "npm run build:eleventy && npm run build:less && npm run build:webpack",
+    "build": "npm run install:demo && npm run build:eleventy && npm run build:less && npm run build:webpack",
     "start:eleventy": "cross-env NODE_ENV=development eleventy --watch",
     "start:webpack": "webpack -w --mode=development",
     "start": "node _tools/dev-server.js",
     "lint": "eslint --ext=.js,.jsx .",
     "test": "npm run lint",
     "fix": "npm run lint -- --fix",
-    "postinstall": "cd src/js/demo && npm install --no-package-lock"
+    "postinstall": "npm run install:demo"
   },
   "dependencies": {
     "anchor-js": "^4.2.2",


### PR DESCRIPTION
Our Netlify build is currently failing with the following output:
```sh
ERROR in ./src/js/demo/components/App.jsx
10:12:12 AM: Module not found: Error: Can't resolve '../node_modules/eslint/lib/linter/linter' in '/opt/build/repo/src/js/demo/components'
10:12:12 AM:  @ ./src/js/demo/components/App.jsx 43:0-68 63:17-29
10:12:12 AM:  @ ./src/js/demo/index.js
10:12:12 AM: ERROR in chunk demo [entry]
10:12:12 AM: demo.js
10:12:12 AM: /opt/build/repo/node_modules/babel-loader/lib/index.js??ref--4!/opt/build/repo/src/js/demo/index.js 8d9c08418e3c67681b9089441452bb1e
10:12:12 AM: Unexpected token (64:17)
10:12:12 AM: | }();
10:12:12 AM: |
10:12:12 AM: | var linter = new !(function webpackMissingModule() { var e = new Error("Cannot find module '../node_modules/eslint/lib/linter/linter'"); e.code = 'MODULE_NOT_FOUND'; throw e; }()).Linter();
10:12:12 AM: | var rules = linter.getRules();
10:12:12 AM: | var ruleNames = Array.from(rules.keys());
10:12:13 AM: npm
10:12:13 AM:  ERR! code ELIFECYCLE
10:12:13 AM: npm
10:12:13 AM:  ERR!
10:12:13 AM: errno 2
10:12:13 AM: npm
10:12:13 AM:  ERR! eslint-website@1.0.0 build:webpack: `webpack --mode=production`
10:12:13 AM: npm
10:12:13 AM:  ERR! Exit status 2
10:12:13 AM: npm
10:12:13 AM: ERR!
10:12:13 AM: npm ERR!
10:12:13 AM:  Failed at the eslint-website@1.0.0 build:webpack script.
```

We're currently installing the latest version of `eslint` in a subpackage for the demo (so that it doesn't interfere with the top-level `eslint `we use to lint the site code) in a `postinstall` script, and it seems like that's not running now. It's possible they switched to running `npm install --ignore-scripts` behind the scenes (possibly for security reasons).

Running the `postinstall` script this before the build step fixes this.