### PR TITLE
Docs: References correct config file name

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -46,7 +46,7 @@ It is also possible to install ESLint globally rather than locally (using `npm i
 
 **Note:** If you are coming from a version before 1.0.0 please see the [migration guide](migrating-to-1.0.0).
 
-After running `eslint --init`, you'll have a `.eslintrc` file in your directory. In it, you'll see some rules configured like this:
+After running `eslint --init`, you'll have a `.eslintrc.{js,yml,json}` file in your directory. In it, you'll see some rules configured like this:
 
 ```json
 {
@@ -65,7 +65,7 @@ The names `"semi"` and `"quotes"` are the names of [rules](/docs/rules) in ESLin
 
 The three error levels allow you fine-grained control over how ESLint applies rules (for more configuration options and details, see the [configuration docs](configuring)).
 
-Your `.eslintrc` configuration file will also include the line:
+Your `.eslintrc.{js,yml,json}` configuration file will also include the line:
 
 ```json
 {


### PR DESCRIPTION
According to the `configuration.md` page, the `.eslintrc` file format has been deprecated, and the `--init` option will generate either a `.yml`, `.js`, or `.json` file depending on what you pick in the initialization wizard.

This commit syncs the getting-started instructions with the configuration instructions.
