### PR TITLE
Docs: fix category descriptions for site generation

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1158,8 +1158,8 @@ categories:
         recommended: false
 deprecated:
   description: >-
-    These rules have been deprecated in accordance with the [deprecation
-    policy](/docs/user-guide/rule-deprecation), and replaced by newer rules:
+    These rules have been deprecated in accordance with the <a href="/docs/user-guide/rule-deprecation">deprecation
+    policy</a>, and replaced by newer rules:
   name: Deprecated
   rules:
     - name: indent-legacy
@@ -1194,8 +1194,8 @@ deprecated:
       replacedBy: []
 removed:
   description: >-
-    These rules from older versions of ESLint (before the [deprecation
-    policy](/docs/user-guide/rule-deprecation) existed) have been replaced by
+    These rules from older versions of ESLint (before the <a href="/docs/user-guide/rule-deprecation">deprecation
+    policy</a> existed) have been replaced by
     newer rules:
   name: Removed
   rules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8047,7 +8047,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -8237,7 +8237,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -10263,7 +10263,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -10427,7 +10427,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {


### PR DESCRIPTION
These descriptions are not run through the Markdown -> HTML generation step, since we blast these over as JSON and use the JSON file as the data source during site generation.

This PR fixes the current live site. Please also see the [corresponding PR](https://github.com/eslint/eslint/pull/12930) to fix this for future releases.