### PR TITLE
Fix: Broken link in 0.24.0 release notes (refs #668)

### DIFF
--- a/_posts/2015-06-26-eslint-0.24.0-released.md
+++ b/_posts/2015-06-26-eslint-0.24.0-released.md
@@ -13,7 +13,7 @@ This is a summary of the major changes you need to know about for this version o
 
 ### 1.0.0 Work Beginning
 
-0.24.0 is the last planned release prior to 1.0.0. We focused mostly on bug fixes and filling functionality gaps in this release, so we are better prepared for 1.0.0. We will still do bugfix releases as necessary, see [the release plans](../preparing-for-1.0.0) for more information.
+0.24.0 is the last planned release prior to 1.0.0. We focused mostly on bug fixes and filling functionality gaps in this release, so we are better prepared for 1.0.0. We will still do bugfix releases as necessary, see [the release plans](preparing-for-1.0.0) for more information.
 
 ### New Rules
 


### PR DESCRIPTION
I checked each link in the original issue https://github.com/eslint/website/issues/668.

Only two were in the blog.
- the link to `/docs/developer-guide/code-path-analysis.html` from `/blog/2016/02/eslint-v2.0.0-released` seems to not be broken.
- This PR fixes the link to `/blog/2015/preparing-for-1.0.0` from `/blog/2015/06/eslint-0.24.0-released`.

The rest were in docs, which cannot be modified in the website repo.  A new issue/PR should be created in the main eslint repo to fix the remaining broken links.