### PR TITLE
Fix: og:image

### DIFF
--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -9,7 +9,7 @@
   <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:title" content="{{ title }}">
   <meta property="og:url" content="{{ page.url | replace: '.html', '' }}">
-  <meta property="og:image" content="/assets/img/favicon.512x512.png">
+  <meta property="og:image" content="https://eslint.org/assets/img/favicon.512x512.png">
   <meta name="twitter:site" content="@geteslint">
   <meta name="twitter:title" content="{{ title }}">
   <meta name="twitter:description" content="{{ site.description }}">

--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -15,7 +15,7 @@
   <meta name="twitter:description" content="{{ site.description }}">
   <meta name="twitter:url" content="{{ page.url | replace: '.html', '' }}">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:image" content="/assets/img/favicon.512x512.png">
+  <meta name="twitter:image" content="https://eslint.org/assets/img/favicon.512x512.png">
   {% if title != site.title %}
       {% if title != "ESLint" %}
           <title>{{ title }} - {{ site.title }}</title>


### PR DESCRIPTION
Currently, `og:image` is not displayed at Twitter card.
`og:image` is url, not path.
https://ogp.me/

https://deploy-preview-703--eslint.netlify.com/
https://cards-dev.twitter.com/validator