### PR TITLE
Fix: argsIgnorePattern documentation for no-unused-vars

### DIFF
--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -232,10 +232,10 @@ var { type, ...coords } = data;
 
 The `argsIgnorePattern` option specifies exceptions not to check for usage: arguments whose names match a regexp pattern. For example, variables whose names begin with an underscore.
 
-Examples of **correct** code for the `{ "argsIgnorePattern": "^_" }` option:
+Examples of **correct** code for the `{ "argsIgnorePattern": /^_/ }` option:
 
 ```js
-/*eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }]*/
+/*eslint no-unused-vars: ["error", { "argsIgnorePattern": /^_/ }]*/
 
 function foo(x, _y) {
     return x + 1;


### PR DESCRIPTION
I used the `argsIgnorePattern` option for the `no-unused-vars` and found out that the documentation on it was wrong. Seems like the pattern has to be set as a regex, not a string as mentioned in the documentation.