### PR TITLE
Build: add webpack mainFields

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,9 +49,7 @@ module.exports = {
     },
     resolve: {
         extensions: [".js", ".jsx"],
-        alias: {
-            esquery: path.resolve(__dirname, "src/js/demo/node_modules/esquery/dist/esquery.js")
-        }
+        mainFields: ["browser", "main", "module"]
     },
     stats: "errors-only"
 };


### PR DESCRIPTION
Demo is currently broken because of the esquery module change.

This should fix it, similar to eslint/eslint#13076

Just had to add `"browser"` as well, bundling was failing on `debug` module without that. I guess we should do the same in the eslint/eslint repo, too.