### PR TITLE
Fix: Broken remaining broken links  (refs #668)

### DIFF
--- a/docs/2.0.0/developer-guide/working-with-rules.md
+++ b/docs/2.0.0/developer-guide/working-with-rules.md
@@ -325,7 +325,7 @@ Keep in mind that comments are technically not a part of the AST and are only at
 ESLint analyzes code paths while traversing AST.
 You can access that code path objects with five events related to code paths.
 
-[details here](./code-path-analysis)
+[details here](./code-path-analysis.html)
 
 ## Rule Unit Tests
 

--- a/docs/4.0.0/user-guide/formatters/html-formatter-example.html
+++ b/docs/4.0.0/user-guide/formatters/html-formatter-example.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>ESLint Report</title>
+        <style>
+            body {
+                font-family:Arial, "Helvetica Neue", Helvetica, sans-serif;
+                font-size:16px;
+                font-weight:normal;
+                margin:0;
+                padding:0;
+                color:#333
+            }
+            #overview {
+                padding:20px 30px
+            }
+            td, th {
+                padding:5px 10px
+            }
+            h1 {
+                margin:0
+            }
+            table {
+                margin:30px;
+                width:calc(100% - 60px);
+                max-width:1000px;
+                border-radius:5px;
+                border:1px solid #ddd;
+                border-spacing:0px;
+            }
+            th {
+                font-weight:400;
+                font-size:medium;
+                text-align:left;
+                cursor:pointer
+            }
+            td.clr-1, td.clr-2, th span {
+                font-weight:700
+            }
+            th span {
+                float:right;
+                margin-left:20px
+            }
+            th span:after {
+                content:"";
+                clear:both;
+                display:block
+            }
+            tr:last-child td {
+                border-bottom:none
+            }
+            tr td:first-child, tr td:last-child {
+                color:#9da0a4
+            }
+            #overview.bg-0, tr.bg-0 th {
+                color:#468847;
+                background:#dff0d8;
+                border-bottom:1px solid #d6e9c6
+            }
+            #overview.bg-1, tr.bg-1 th {
+                color:#f0ad4e;
+                background:#fcf8e3;
+                border-bottom:1px solid #fbeed5
+            }
+            #overview.bg-2, tr.bg-2 th {
+                color:#b94a48;
+                background:#f2dede;
+                border-bottom:1px solid #eed3d7
+            }
+            td {
+                border-bottom:1px solid #ddd
+            }
+            td.clr-1 {
+                color:#f0ad4e
+            }
+            td.clr-2 {
+                color:#b94a48
+            }
+            td a {
+                color:#3a33d1;
+                text-decoration:none
+            }
+            td a:hover {
+                color:#272296;
+                text-decoration:underline
+            }
+        </style>
+    </head>
+    <body>
+        <div id="overview" class="bg-2">
+            <h1>ESLint Report</h1>
+            <div>
+                <span>9 problems (5 errors, 4 warnings)</span> - Generated on Wed Mar 21 2018 20:27:31 GMT-0400 (EDT)
+            </div>
+        </div>
+        <table>
+            <tbody>
+                <tr class="bg-2" data-group="f-0">
+    <th colspan="4">
+        [+] /var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js
+        <span>9 problems (5 errors, 4 warnings)</span>
+    </th>
+</tr>
+<tr style="display:none" class="f-0">
+    <td>1:10</td>
+    <td class="clr-2">Error</td>
+    <td>&#39;addOne&#39; is defined but never used.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/no-unused-vars" target="_blank">no-unused-vars</a>
+    </td>
+</tr>
+
+<tr style="display:none" class="f-0">
+    <td>2:9</td>
+    <td class="clr-2">Error</td>
+    <td>Use the isNaN function to compare with NaN.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/use-isnan" target="_blank">use-isnan</a>
+    </td>
+</tr>
+
+<tr style="display:none" class="f-0">
+    <td>3:16</td>
+    <td class="clr-2">Error</td>
+    <td>Unexpected space before unary operator &#39;++&#39;.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/space-unary-ops" target="_blank">space-unary-ops</a>
+    </td>
+</tr>
+
+<tr style="display:none" class="f-0">
+    <td>3:20</td>
+    <td class="clr-1">Warning</td>
+    <td>Missing semicolon.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/semi" target="_blank">semi</a>
+    </td>
+</tr>
+
+<tr style="display:none" class="f-0">
+    <td>4:12</td>
+    <td class="clr-1">Warning</td>
+    <td>Unnecessary &#39;else&#39; after &#39;return&#39;.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/no-else-return" target="_blank">no-else-return</a>
+    </td>
+</tr>
+
+<tr style="display:none" class="f-0">
+    <td>5:1</td>
+    <td class="clr-1">Warning</td>
+    <td>Expected indentation of 8 spaces but found 6.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/indent" target="_blank">indent</a>
+    </td>
+</tr>
+
+<tr style="display:none" class="f-0">
+    <td>5:7</td>
+    <td class="clr-2">Error</td>
+    <td>Function &#39;addOne&#39; expected a return value.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/consistent-return" target="_blank">consistent-return</a>
+    </td>
+</tr>
+
+<tr style="display:none" class="f-0">
+    <td>5:13</td>
+    <td class="clr-1">Warning</td>
+    <td>Missing semicolon.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/semi" target="_blank">semi</a>
+    </td>
+</tr>
+
+<tr style="display:none" class="f-0">
+    <td>7:2</td>
+    <td class="clr-2">Error</td>
+    <td>Unnecessary semicolon.</td>
+    <td>
+        <a href="https://eslint.org/docs/rules/no-extra-semi" target="_blank">no-extra-semi</a>
+    </td>
+</tr>
+
+            </tbody>
+        </table>
+        <script type="text/javascript">
+            var groups = document.querySelectorAll("tr[data-group]");
+            for (i = 0; i < groups.length; i++) {
+                groups[i].addEventListener("click", function() {
+                    var inGroup = document.getElementsByClassName(this.getAttribute("data-group"));
+                    this.innerHTML = (this.innerHTML.indexOf("+") > -1) ? this.innerHTML.replace("+", "-") : this.innerHTML.replace("-", "+");
+                    for (var j = 0; j < inGroup.length; j++) {
+                        inGroup[j].style.display = (inGroup[j].style.display !== "none") ? "none" : "table-row";
+                    }
+                });
+            }
+        </script>
+    </body>
+</html>

--- a/docs/4.0.0/user-guide/formatters/index.md
+++ b/docs/4.0.0/user-guide/formatters/index.md
@@ -1,0 +1,335 @@
+---
+title: Documentation
+layout: doc
+---
+# ESLint Formatters
+
+ESLint comes with several built-in formatters to control the appearance of the linting results, and supports third-party formatters as well.
+
+You can specify a formatter using the `--format` or `-f` flag on the command line. For example, `--format codeframe` uses the `codeframe` formatter.
+
+The built-in formatter options are:
+
+* [checkstyle](#checkstyle)
+* [codeframe](#codeframe)
+* [compact](#compact)
+* [html](#html)
+* [jslint-xml](#jslint-xml)
+* [json](#json)
+* [junit](#junit)
+* [stylish](#stylish)
+* [table](#table)
+* [tap](#tap)
+* [unix](#unix)
+* [visualstudio](#visualstudio)
+
+## Example Source
+
+Examples of each formatter were created from linting `fullOfProblems.js` using the `.eslintrc` configuration shown below.
+
+### `fullOfProblems.js`
+
+```js
+function addOne(i) {
+    if (i != NaN) {
+        return i ++
+    } else {
+      return
+    }
+};
+```
+
+### `.eslintrc`:
+
+```json
+{
+    "extends": "eslint:recommended",
+    "rules": {
+        "consistent-return": 2,
+        "indent"           : [1, 4],
+        "no-else-return"   : 1,
+        "semi"             : [1, "always"],
+        "space-unary-ops"  : 2
+    }
+}
+```
+
+## Output Examples
+
+### checkstyle
+```
+<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js"><error line="1" column="10" severity="error" message="&apos;addOne&apos; is defined but never used. (no-unused-vars)" source="eslint.rules.no-unused-vars" /><error line="2" column="9" severity="error" message="Use the isNaN function to compare with NaN. (use-isnan)" source="eslint.rules.use-isnan" /><error line="3" column="16" severity="error" message="Unexpected space before unary operator &apos;++&apos;. (space-unary-ops)" source="eslint.rules.space-unary-ops" /><error line="3" column="20" severity="warning" message="Missing semicolon. (semi)" source="eslint.rules.semi" /><error line="4" column="12" severity="warning" message="Unnecessary &apos;else&apos; after &apos;return&apos;. (no-else-return)" source="eslint.rules.no-else-return" /><error line="5" column="1" severity="warning" message="Expected indentation of 8 spaces but found 6. (indent)" source="eslint.rules.indent" /><error line="5" column="7" severity="error" message="Function &apos;addOne&apos; expected a return value. (consistent-return)" source="eslint.rules.consistent-return" /><error line="5" column="13" severity="warning" message="Missing semicolon. (semi)" source="eslint.rules.semi" /><error line="7" column="2" severity="error" message="Unnecessary semicolon. (no-extra-semi)" source="eslint.rules.no-extra-semi" /></file></checkstyle>
+```
+
+### codeframe
+```
+error: 'addOne' is defined but never used (no-unused-vars) at fullOfProblems.js:1:10:
+> 1 | function addOne(i) {
+    |          ^
+  2 |     if (i != NaN) {
+  3 |         return i ++
+  4 |     } else {
+
+
+error: Use the isNaN function to compare with NaN (use-isnan) at fullOfProblems.js:2:9:
+  1 | function addOne(i) {
+> 2 |     if (i != NaN) {
+    |         ^
+  3 |         return i ++
+  4 |     } else {
+  5 |       return
+
+
+error: Unexpected space before unary operator '++' (space-unary-ops) at fullOfProblems.js:3:16:
+  1 | function addOne(i) {
+  2 |     if (i != NaN) {
+> 3 |         return i ++
+    |                ^
+  4 |     } else {
+  5 |       return
+  6 |     }
+
+
+warning: Missing semicolon (semi) at fullOfProblems.js:3:20:
+  1 | function addOne(i) {
+  2 |     if (i != NaN) {
+> 3 |         return i ++
+    |                    ^
+  4 |     } else {
+  5 |       return
+  6 |     }
+
+
+warning: Unnecessary 'else' after 'return' (no-else-return) at fullOfProblems.js:4:12:
+  2 |     if (i != NaN) {
+  3 |         return i ++
+> 4 |     } else {
+    |            ^
+  5 |       return
+  6 |     }
+  7 | };
+
+
+warning: Expected indentation of 8 spaces but found 6 (indent) at fullOfProblems.js:5:1:
+  3 |         return i ++
+  4 |     } else {
+> 5 |       return
+    | ^
+  6 |     }
+  7 | };
+
+
+error: Function 'addOne' expected a return value (consistent-return) at fullOfProblems.js:5:7:
+  3 |         return i ++
+  4 |     } else {
+> 5 |       return
+    |       ^
+  6 |     }
+  7 | };
+
+
+warning: Missing semicolon (semi) at fullOfProblems.js:5:13:
+  3 |         return i ++
+  4 |     } else {
+> 5 |       return
+    |             ^
+  6 |     }
+  7 | };
+
+
+error: Unnecessary semicolon (no-extra-semi) at fullOfProblems.js:7:2:
+  5 |       return
+  6 |     }
+> 7 | };
+    |  ^
+
+
+5 errors and 4 warnings found.
+2 errors and 4 warnings potentially fixable with the `--fix` option.
+```
+
+### compact
+```
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 1, col 10, Error - 'addOne' is defined but never used. (no-unused-vars)
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 2, col 9, Error - Use the isNaN function to compare with NaN. (use-isnan)
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 3, col 16, Error - Unexpected space before unary operator '++'. (space-unary-ops)
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 3, col 20, Warning - Missing semicolon. (semi)
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 4, col 12, Warning - Unnecessary 'else' after 'return'. (no-else-return)
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 5, col 1, Warning - Expected indentation of 8 spaces but found 6. (indent)
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 5, col 7, Error - Function 'addOne' expected a return value. (consistent-return)
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 5, col 13, Warning - Missing semicolon. (semi)
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js: line 7, col 2, Error - Unnecessary semicolon. (no-extra-semi)
+
+9 problems
+```
+
+### html
+<iframe src="html-formatter-example.html" width="100%" height="460px"></iframe>
+
+### jslint-xml
+```
+<?xml version="1.0" encoding="utf-8"?><jslint><file name="/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js"><issue line="1" char="10" evidence="function addOne(i) {" reason="&apos;addOne&apos; is defined but never used. (no-unused-vars)" /><issue line="2" char="9" evidence="    if (i != NaN) {" reason="Use the isNaN function to compare with NaN. (use-isnan)" /><issue line="3" char="16" evidence="        return i ++" reason="Unexpected space before unary operator &apos;++&apos;. (space-unary-ops)" /><issue line="3" char="20" evidence="        return i ++" reason="Missing semicolon. (semi)" /><issue line="4" char="12" evidence="    } else {" reason="Unnecessary &apos;else&apos; after &apos;return&apos;. (no-else-return)" /><issue line="5" char="1" evidence="      return" reason="Expected indentation of 8 spaces but found 6. (indent)" /><issue line="5" char="7" evidence="      return" reason="Function &apos;addOne&apos; expected a return value. (consistent-return)" /><issue line="5" char="13" evidence="      return" reason="Missing semicolon. (semi)" /><issue line="7" char="2" evidence="};" reason="Unnecessary semicolon. (no-extra-semi)" /></file></jslint>
+```
+
+### json
+```
+[{"filePath":"/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js","messages":[{"ruleId":"no-unused-vars","severity":2,"message":"'addOne' is defined but never used.","line":1,"column":10,"nodeType":"Identifier","source":"function addOne(i) {","endLine":1,"endColumn":16},{"ruleId":"use-isnan","severity":2,"message":"Use the isNaN function to compare with NaN.","line":2,"column":9,"nodeType":"BinaryExpression","source":"    if (i != NaN) {","endLine":2,"endColumn":17},{"ruleId":"space-unary-ops","severity":2,"message":"Unexpected space before unary operator '++'.","line":3,"column":16,"nodeType":"UpdateExpression","source":"        return i ++","endLine":3,"endColumn":20,"fix":{"range":[57,58],"text":""}},{"ruleId":"semi","severity":1,"message":"Missing semicolon.","line":3,"column":20,"nodeType":"ReturnStatement","source":"        return i ++","fix":{"range":[60,60],"text":";"}},{"ruleId":"no-else-return","severity":1,"message":"Unnecessary 'else' after 'return'.","line":4,"column":12,"nodeType":"BlockStatement","source":"    } else {","messageId":"unexpected","endLine":6,"endColumn":6,"fix":{"range":[0,94],"text":"function addOne(i) {\n    if (i != NaN) {\n        return i ++\n    } \n      return\n    \n}"}},{"ruleId":"indent","severity":1,"message":"Expected indentation of 8 spaces but found 6.","line":5,"column":1,"nodeType":"Keyword","source":"      return","endLine":5,"endColumn":7,"fix":{"range":[74,80],"text":"        "}},{"ruleId":"consistent-return","severity":2,"message":"Function 'addOne' expected a return value.","line":5,"column":7,"nodeType":"ReturnStatement","source":"      return","messageId":"missingReturnValue","endLine":5,"endColumn":13},{"ruleId":"semi","severity":1,"message":"Missing semicolon.","line":5,"column":13,"nodeType":"ReturnStatement","source":"      return","fix":{"range":[86,86],"text":";"}},{"ruleId":"no-extra-semi","severity":2,"message":"Unnecessary semicolon.","line":7,"column":2,"nodeType":"EmptyStatement","source":"};","messageId":"unexpected","endLine":7,"endColumn":3,"fix":{"range":[93,95],"text":"}"}}],"errorCount":5,"warningCount":4,"fixableErrorCount":2,"fixableWarningCount":4,"source":"function addOne(i) {\n    if (i != NaN) {\n        return i ++\n    } else {\n      return\n    }\n};"}]
+```
+
+### junit
+```
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+<testsuite package="org.eslint" time="0" tests="9" errors="9" name="/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js">
+<testcase time="0" name="org.eslint.no-unused-vars"><failure message="&apos;addOne&apos; is defined but never used."><![CDATA[line 1, col 10, Error - &apos;addOne&apos; is defined but never used. (no-unused-vars)]]></failure></testcase>
+<testcase time="0" name="org.eslint.use-isnan"><failure message="Use the isNaN function to compare with NaN."><![CDATA[line 2, col 9, Error - Use the isNaN function to compare with NaN. (use-isnan)]]></failure></testcase>
+<testcase time="0" name="org.eslint.space-unary-ops"><failure message="Unexpected space before unary operator &apos;++&apos;."><![CDATA[line 3, col 16, Error - Unexpected space before unary operator &apos;++&apos;. (space-unary-ops)]]></failure></testcase>
+<testcase time="0" name="org.eslint.semi"><failure message="Missing semicolon."><![CDATA[line 3, col 20, Warning - Missing semicolon. (semi)]]></failure></testcase>
+<testcase time="0" name="org.eslint.no-else-return"><failure message="Unnecessary &apos;else&apos; after &apos;return&apos;."><![CDATA[line 4, col 12, Warning - Unnecessary &apos;else&apos; after &apos;return&apos;. (no-else-return)]]></failure></testcase>
+<testcase time="0" name="org.eslint.indent"><failure message="Expected indentation of 8 spaces but found 6."><![CDATA[line 5, col 1, Warning - Expected indentation of 8 spaces but found 6. (indent)]]></failure></testcase>
+<testcase time="0" name="org.eslint.consistent-return"><failure message="Function &apos;addOne&apos; expected a return value."><![CDATA[line 5, col 7, Error - Function &apos;addOne&apos; expected a return value. (consistent-return)]]></failure></testcase>
+<testcase time="0" name="org.eslint.semi"><failure message="Missing semicolon."><![CDATA[line 5, col 13, Warning - Missing semicolon. (semi)]]></failure></testcase>
+<testcase time="0" name="org.eslint.no-extra-semi"><failure message="Unnecessary semicolon."><![CDATA[line 7, col 2, Error - Unnecessary semicolon. (no-extra-semi)]]></failure></testcase>
+</testsuite>
+</testsuites>
+
+```
+
+### stylish
+```
+
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js
+  1:10  error    'addOne' is defined but never used            no-unused-vars
+  2:9   error    Use the isNaN function to compare with NaN    use-isnan
+  3:16  error    Unexpected space before unary operator '++'   space-unary-ops
+  3:20  warning  Missing semicolon                             semi
+  4:12  warning  Unnecessary 'else' after 'return'             no-else-return
+  5:1   warning  Expected indentation of 8 spaces but found 6  indent
+  5:7   error    Function 'addOne' expected a return value     consistent-return
+  5:13  warning  Missing semicolon                             semi
+  7:2   error    Unnecessary semicolon                         no-extra-semi
+
+✖ 9 problems (5 errors, 4 warnings)
+  2 errors, 4 warnings potentially fixable with the `--fix` option.
+
+```
+
+### table
+```
+
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js
+
+║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║
+╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢
+║ 1        │ 10       │ error    │ 'addOne' is defined but never used.                    │ no-unused-vars       ║
+║ 2        │ 9        │ error    │ Use the isNaN function to compare with NaN.            │ use-isnan            ║
+║ 3        │ 16       │ error    │ Unexpected space before unary operator '++'.           │ space-unary-ops      ║
+║ 3        │ 20       │ warning  │ Missing semicolon.                                     │ semi                 ║
+║ 4        │ 12       │ warning  │ Unnecessary 'else' after 'return'.                     │ no-else-return       ║
+║ 5        │ 1        │ warning  │ Expected indentation of 8 spaces but found 6.          │ indent               ║
+║ 5        │ 7        │ error    │ Function 'addOne' expected a return value.             │ consistent-return    ║
+║ 5        │ 13       │ warning  │ Missing semicolon.                                     │ semi                 ║
+║ 7        │ 2        │ error    │ Unnecessary semicolon.                                 │ no-extra-semi        ║
+
+╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
+║ 5 Errors                                                                                                       ║
+╟────────────────────────────────────────────────────────────────────────────────────────────────────────────────╢
+║ 4 Warnings                                                                                                     ║
+╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝
+
+```
+
+### tap
+```
+TAP version 13
+1..1
+not ok 1 - /var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js
+  ---
+  message: '''addOne'' is defined but never used.'
+  severity: error
+  data:
+    line: 1
+    column: 10
+    ruleId: no-unused-vars
+  messages:
+    - message: Use the isNaN function to compare with NaN.
+      severity: error
+      data:
+        line: 2
+        column: 9
+        ruleId: use-isnan
+    - message: Unexpected space before unary operator '++'.
+      severity: error
+      data:
+        line: 3
+        column: 16
+        ruleId: space-unary-ops
+    - message: Missing semicolon.
+      severity: warning
+      data:
+        line: 3
+        column: 20
+        ruleId: semi
+    - message: Unnecessary 'else' after 'return'.
+      severity: warning
+      data:
+        line: 4
+        column: 12
+        ruleId: no-else-return
+    - message: Expected indentation of 8 spaces but found 6.
+      severity: warning
+      data:
+        line: 5
+        column: 1
+        ruleId: indent
+    - message: Function 'addOne' expected a return value.
+      severity: error
+      data:
+        line: 5
+        column: 7
+        ruleId: consistent-return
+    - message: Missing semicolon.
+      severity: warning
+      data:
+        line: 5
+        column: 13
+        ruleId: semi
+    - message: Unnecessary semicolon.
+      severity: error
+      data:
+        line: 7
+        column: 2
+        ruleId: no-extra-semi
+  ...
+
+```
+
+### unix
+```
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:1:10: 'addOne' is defined but never used. [Error/no-unused-vars]
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:2:9: Use the isNaN function to compare with NaN. [Error/use-isnan]
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:3:16: Unexpected space before unary operator '++'. [Error/space-unary-ops]
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:3:20: Missing semicolon. [Warning/semi]
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:4:12: Unnecessary 'else' after 'return'. [Warning/no-else-return]
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:5:1: Expected indentation of 8 spaces but found 6. [Warning/indent]
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:5:7: Function 'addOne' expected a return value. [Error/consistent-return]
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:5:13: Missing semicolon. [Warning/semi]
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js:7:2: Unnecessary semicolon. [Error/no-extra-semi]
+
+9 problems
+```
+
+### visualstudio
+```
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(1,10): error no-unused-vars : 'addOne' is defined but never used.
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(2,9): error use-isnan : Use the isNaN function to compare with NaN.
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(3,16): error space-unary-ops : Unexpected space before unary operator '++'.
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(3,20): warning semi : Missing semicolon.
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(4,12): warning no-else-return : Unnecessary 'else' after 'return'.
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(5,1): warning indent : Expected indentation of 8 spaces but found 6.
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(5,7): error consistent-return : Function 'addOne' expected a return value.
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(5,13): warning semi : Missing semicolon.
+/var/lib/jenkins/workspace/Releases/ESLint Release/eslint/fullOfProblems.js(7,2): error no-extra-semi : Unnecessary semicolon.
+
+9 problems
+```

--- a/docs/5.0.0/rules/index.md
+++ b/docs/5.0.0/rules/index.md
@@ -1,0 +1,117 @@
+---
+title: List of available rules
+layout: doc
+---
+
+# Rules
+
+Rules in ESLint are grouped by category to help you understand their purpose.
+
+No rules are enabled by default. The `"extends": "eslint:recommended"` property in a [configuration file](../user-guide/configuring#extending-configuration-files) enables rules that report common problems, which have a check mark (recommended) below.
+
+The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems (currently mostly whitespace) reported by rules which have a wrench (fixable) below.
+
+{% for category in site.data.rules.categories %}
+
+## {{ category.name}}
+
+{{ category.description }}
+
+<table class="rule-list table table-striped">
+<colgroup>
+<col class="recommended" />
+<col class="fixable" />
+<col class="name" />
+<col class="description" />
+</colgroup>
+<tbody>
+{% for rule in category.rules %}
+<tr>
+<td>{% if rule.recommended %}(recommended){% endif %}</td>
+<td>{% if rule.fixable %}(fixable){% endif %}</td>
+<td markdown="1">[{{rule.name}}]({{rule.name}})
+</td>
+<td markdown="1">{{rule.description}}
+</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+
+{% endfor %}
+
+{% if site.data.rules.deprecated %}
+## {{ site.data.rules.deprecated.name }}
+
+{{ site.data.rules.deprecated.description }}
+
+<div class="rule-list deprecated-rules">
+<table class="table table-striped">
+
+<colgroup>
+<col class="name" />
+<col class="replaced-by" />
+</colgroup>
+
+<thead>
+<tr>
+<th>Deprecated rule</th>
+<th>Replaced by</th>
+</tr>
+</thead>
+
+<tbody>
+{% for rule in site.data.rules.deprecated.rules %}
+<tr>
+<td markdown="1">[{{rule.name}}]({{rule.name}})
+</td>
+{% if rule.replacedBy.size > 0 %}
+<td class="replaced-by" markdown="1">{% for replaced in rule.replacedBy %}[{{replaced}}]({{replaced}}){% endfor %}
+{% else %}
+<td class="replaced-by" markdown="1"><p class="text-muted">(no replacement)</p>
+{% endif %}
+</td>
+</tr>
+{% endfor %}
+</tbody>
+
+</table>
+</div>
+{% endif %}
+
+## {{ site.data.rules.removed.name }}
+
+{{ site.data.rules.removed.description }}
+
+<div class="rule-list removed-rules">
+<table class="table table-striped">
+
+<colgroup>
+<col class="name" />
+<col class="replaced-by" />
+</colgroup>
+
+<thead>
+<tr>
+<th>Removed rule</th>
+<th>Replaced by</th>
+</tr>
+</thead>
+
+<tbody>
+{% for rule in site.data.rules.removed.rules %}
+<tr>
+<td markdown="1">[{{rule.removed}}]({{rule.removed}})
+</td>
+{% if rule.replacedBy.size > 0 %}
+<td class="replaced-by" markdown="1">{% for replaced in rule.replacedBy %}[{{replaced}}]({{replaced}}){% endfor %}
+{% else %}
+<td class="replaced-by" markdown="1"><p class="text-muted">(no replacement)</p>
+{% endif %}
+</td>
+</tr>
+{% endfor %}
+</tbody>
+
+</table>
+</div>

--- a/docs/6.0.0/rules/default-param-last.md
+++ b/docs/6.0.0/rules/default-param-last.md
@@ -1,0 +1,52 @@
+---
+title: default-param-last - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/default-param-last.md
+rule_type: suggestion
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# enforce default parameters to be last (default-param-last)
+
+Putting default parameter at last allows function calls to omit optional tail arguments.
+
+```js
+// Correct: optional argument can be omitted
+function createUser(id, isAdmin = false) {}
+createUser("tabby")
+
+// Incorrect: optional argument can **not** be omitted
+function createUser(isAdmin = false, id) {}
+createUser(undefined, "tabby")
+```
+
+## Rule Details
+
+This rule enforces default parameters to be the last of parameters.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint default-param-last: ["error"] */
+
+function f(a = 0, b) {}
+
+function f(a, b = 0, c) {}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint default-param-last: ["error"] */
+
+function f(a, b = 0) {}
+```
+
+## Version
+
+This rule was introduced in ESLint 6.4.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/default-param-last.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/default-param-last.md)

--- a/docs/6.0.0/rules/function-call-argument-newline.md
+++ b/docs/6.0.0/rules/function-call-argument-newline.md
@@ -1,0 +1,221 @@
+---
+title: function-call-argument-newline - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/function-call-argument-newline.md
+rule_type: layout
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# enforce line breaks between arguments of a function call (function-call-argument-newline)
+
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+A number of style guides require or disallow line breaks between arguments of a function call.
+
+## Rule Details
+
+This rule enforces line breaks between arguments of a function call.
+
+## Options
+
+This rule has a string option:
+
+* `"always"` (default) requires line breaks between arguments
+* `"never"` disallows line breaks between arguments
+* `"consistent"` requires consistent usage of line breaks between arguments
+
+
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "always"]*/
+
+foo("one", "two", "three");
+
+bar("one", "two", {
+    one: 1,
+    two: 2
+});
+
+baz("one", "two", (x) => {
+    console.log(x);
+});
+```
+
+Examples of **correct** code for this rule with the default `"always"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "always"]*/
+
+foo(
+    "one",
+    "two",
+    "three"
+);
+
+bar(
+    "one",
+    "two",
+    { one: 1, two: 2 }
+);
+// or
+bar(
+    "one",
+    "two",
+    {
+        one: 1,
+        two: 2
+    }
+);
+
+baz(
+    "one",
+    "two",
+    (x) => {
+        console.log(x);
+    }
+);
+```
+
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "never"]*/
+
+foo(
+    "one",
+    "two", "three"
+);
+
+bar(
+    "one",
+    "two", {
+        one: 1,
+        two: 2
+    }
+);
+
+baz(
+    "one",
+    "two", (x) => {
+        console.log(x);
+    }
+);
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "never"]*/
+
+foo("one", "two", "three");
+// or
+foo(
+    "one", "two", "three"
+);
+
+bar("one", "two", { one: 1, two: 2 });
+// or
+bar("one", "two", {
+    one: 1,
+    two: 2
+});
+
+baz("one", "two", (x) => {
+    console.log(x);
+});
+```
+
+### consistent
+
+Examples of **incorrect** code for this rule with the default `"consistent"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "consistent"]*/
+
+foo("one", "two",
+    "three");
+//or
+foo("one",
+    "two", "three");
+
+bar("one", "two",
+    { one: 1, two: 2}
+);
+
+baz("one", "two",
+    (x) => { console.log(x); }
+);
+```
+
+Examples of **correct** code for this rule with the default `"consistent"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "consistent"]*/
+
+foo("one", "two", "three");
+// or
+foo(
+    "one",
+    "two",
+    "three"
+);
+
+bar("one", "two", {
+    one: 1,
+    two: 2
+});
+// or
+bar(
+    "one",
+    "two",
+    { one: 1, two: 2 }
+);
+// or
+bar(
+    "one",
+    "two",
+    {
+        one: 1,
+        two: 2
+    }
+);
+
+baz("one", "two", (x) => {
+    console.log(x);
+});
+// or
+baz(
+    "one",
+    "two",
+    (x) => {
+        console.log(x);
+    }
+);
+```
+
+
+## When Not To Use It
+
+If you don't want to enforce line breaks between arguments, don't enable this rule.
+
+## Related Rules
+
+* [function-paren-newline](function-paren-newline)
+* [func-call-spacing](func-call-spacing)
+* [object-property-newline](object-property-newline)
+* [array-element-newline](array-element-newline)
+
+## Version
+
+This rule was introduced in ESLint 6.2.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/function-call-argument-newline.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/function-call-argument-newline.md)

--- a/docs/6.0.0/rules/grouped-accessor-pairs.md
+++ b/docs/6.0.0/rules/grouped-accessor-pairs.md
@@ -1,0 +1,343 @@
+---
+title: grouped-accessor-pairs - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/grouped-accessor-pairs.md
+rule_type: suggestion
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# Require grouped accessor pairs in object literals and classes (grouped-accessor-pairs)
+
+A getter and setter for the same property don't necessarily have to be defined adjacent to each other.
+
+For example, the following statements would create the same object:
+
+```js
+var o = {
+    get a() {
+        return this.val;
+    },
+    set a(value) {
+        this.val = value;
+    },
+    b: 1
+};
+
+var o = {
+    get a() {
+        return this.val;
+    },
+    b: 1,
+    set a(value) {
+        this.val = value;
+    }
+};
+```
+
+While it is allowed to define the pair for a getter or a setter anywhere in an object or class definition, it's considered a best practice to group accessor functions for the same property.
+
+In other words, if a property has a getter and a setter, the setter should be defined right after the getter, or vice versa.
+
+## Rule Details
+
+This rule requires grouped definitions of accessor functions for the same property in object literals, class declarations and class expressions.
+
+Optionally, this rule can also enforce consistent order (`getBeforeSet` or `setBeforeGet`).
+
+This rule does not enforce the existence of the pair for a getter or a setter. See [accessor-pairs](accessor-pairs) if you also want to enforce getter/setter pairs.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint grouped-accessor-pairs: "error"*/
+
+var foo = {
+    get a() {
+        return this.val;
+    },
+    b: 1,
+    set a(value) {
+        this.val = value;
+    }
+};
+
+var bar = {
+    set b(value) {
+        this.val = value;
+    },
+    a: 1,
+    get b() {
+        return this.val;
+    }
+}
+
+class Foo {
+    set a(value) {
+        this.val = value;
+    }
+    b(){}
+    get a() {
+        return this.val;
+    }
+}
+
+const Bar = class {
+    static get a() {
+        return this.val;
+    }
+    b(){}
+    static set a(value) {
+        this.val = value;
+    }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint grouped-accessor-pairs: "error"*/
+
+var foo = {
+    get a() {
+        return this.val;
+    },
+    set a(value) {
+        this.val = value;
+    },
+    b: 1
+};
+
+var bar = {
+    set b(value) {
+        this.val = value;
+    },
+    get b() {
+        return this.val;
+    },
+    a: 1
+}
+
+class Foo {
+    set a(value) {
+        this.val = value;
+    }
+    get a() {
+        return this.val;
+    }
+    b(){}
+}
+
+const Bar = class {
+    static get a() {
+        return this.val;
+    }
+    static set a(value) {
+        this.val = value;
+    }
+    b(){}
+}
+```
+
+## Options
+
+This rule has a string option:
+
+* `"anyOrder"` (default) does not enforce order.
+* `"getBeforeSet"` if a property has both getter and setter, requires the getter to be defined before the setter.
+* `"setBeforeGet"` if a property has both getter and setter, requires the setter to be defined before the getter.
+
+### getBeforeSet
+
+Examples of **incorrect** code for this rule with the `"getBeforeSet"` option:
+
+```js
+/*eslint grouped-accessor-pairs: ["error", "getBeforeSet"]*/
+
+var foo = {
+    set a(value) {
+        this.val = value;
+    },
+    get a() {
+        return this.val;
+    }
+};
+
+class Foo {
+    set a(value) {
+        this.val = value;
+    }
+    get a() {
+        return this.val;
+    }
+}
+
+const Bar = class {
+    static set a(value) {
+        this.val = value;
+    }
+    static get a() {
+        return this.val;
+    }
+}
+```
+
+Examples of **correct** code for this rule with the `"getBeforeSet"` option:
+
+```js
+/*eslint grouped-accessor-pairs: ["error", "getBeforeSet"]*/
+
+var foo = {
+    get a() {
+        return this.val;
+    },
+    set a(value) {
+        this.val = value;
+    }
+};
+
+class Foo {
+    get a() {
+        return this.val;
+    }
+    set a(value) {
+        this.val = value;
+    }
+}
+
+const Bar = class {
+    static get a() {
+        return this.val;
+    }
+    static set a(value) {
+        this.val = value;
+    }
+}
+```
+
+### setBeforeGet
+
+Examples of **incorrect** code for this rule with the `"setBeforeGet"` option:
+
+```js
+/*eslint grouped-accessor-pairs: ["error", "setBeforeGet"]*/
+
+var foo = {
+    get a() {
+        return this.val;
+    },
+    set a(value) {
+        this.val = value;
+    }
+};
+
+class Foo {
+    get a() {
+        return this.val;
+    }
+    set a(value) {
+        this.val = value;
+    }
+}
+
+const Bar = class {
+    static get a() {
+        return this.val;
+    }
+    static set a(value) {
+        this.val = value;
+    }
+}
+```
+
+Examples of **correct** code for this rule with the `"setBeforeGet"` option:
+
+```js
+/*eslint grouped-accessor-pairs: ["error", "setBeforeGet"]*/
+
+var foo = {
+    set a(value) {
+        this.val = value;
+    },
+    get a() {
+        return this.val;
+    }
+};
+
+class Foo {
+    set a(value) {
+        this.val = value;
+    }
+    get a() {
+        return this.val;
+    }
+}
+
+const Bar = class {
+    static set a(value) {
+        this.val = value;
+    }
+    static get a() {
+        return this.val;
+    }
+}
+```
+
+## Known Limitations
+
+Due to the limits of static analysis, this rule does not account for possible side effects and in certain cases
+might require or miss to require grouping or order for getters/setters that have a computed key, like in the following example:
+
+```js
+/*eslint grouped-accessor-pairs: "error"*/
+
+var a = 1;
+
+// false warning (false positive)
+var foo = {
+    get [a++]() {
+        return this.val;
+    },
+    b: 1,
+    set [a++](value) {
+        this.val = value;
+    }
+};
+
+// missed warning (false negative)
+var bar = {
+    get [++a]() {
+        return this.val;
+    },
+    b: 1,
+    set [a](value) {
+        this.val = value;
+    }
+};
+```
+
+Also, this rule does not report any warnings for properties that have duplicate getters or setters.
+
+See [no-dupe-keys](no-dupe-keys) if you also want to disallow duplicate keys in object literals.
+
+See [no-dupe-class-members](no-dupe-class-members) if you also want to disallow duplicate names in class definitions.
+
+## Further Reading
+
+* [Object Setters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set)
+* [Object Getters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get)
+* [Classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes)
+
+## Related Rules
+
+* [accessor-pairs](accessor-pairs)
+* [no-dupe-keys](no-dupe-keys)
+* [no-dupe-class-members](no-dupe-class-members)
+
+## Version
+
+This rule was introduced in ESLint 6.7.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/grouped-accessor-pairs.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/grouped-accessor-pairs.md)

--- a/docs/6.0.0/rules/index.liquid
+++ b/docs/6.0.0/rules/index.liquid
@@ -1,0 +1,105 @@
+---
+title: List of available rules
+layout: doc
+---
+
+<h1>Rules</h1>
+<p>Rules in ESLint are grouped by category to help you understand their purpose.</p>
+<p>No rules are enabled by default. The <code>"extends": "eslint:recommended"</code> property in a <a href="../user-guide/configuring#extending-configuration-files">configuration file</a> enables rules that report common problems, which have a check mark (recommended) below.</p>
+<p>The `--fix` option on the <a href="../user-guide/command-line-interface#fix">command line</a> automatically fixes problems (currently mostly whitespace) reported by rules which have a wrench (fixable) below.</p>
+{% for category in rules.categories %}
+  <h2>{{ category.name }}</h2>
+  {{ category.description }}
+  <table class="rule-list table table-striped">
+    <colgroup>
+      <col class="recommended" />
+      <col class="fixable" />
+      <col class="name" />
+      <col class="description" />
+    </colgroup>
+    <tbody>
+      {% for rule in category.rules %}
+        <tr>
+        <td>{% if rule.recommended %}(recommended){% endif %}</td>
+        <td>{% if rule.fixable %}(fixable){% endif %}</td>
+        <td markdown="1"><a href="{{ rule.name }}">{{ rule.name }}</a> </td>
+        <td markdown="1">{{ rule.description }} </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endfor %}
+{% if rules.deprecated %}
+  <h2>{{ rules.deprecated.name }}</h2>
+  {{ rules.deprecated.description }}
+  <div class="rule-list deprecated-rules">
+    <table class="table table-striped">
+      <colgroup>
+        <col class="name" />
+        <col class="replaced-by" />
+      </colgroup>
+      <thead>
+        <tr>
+          <th>Deprecated rule</th>
+          <th>Replaced by</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for rule in rules.deprecated.rules %}
+          <tr>
+            <td markdown="1">
+              <a href="{{ rule.name }}">{{ rule.name }}</a>
+            </td>
+            {% if rule.replacedBy.size > 0 %}
+              <td class="replaced-by" markdown="1">
+                {% for replaced in rule.replacedBy %}
+                <a href="{{ replaced }}">{{ replaced }}</a>
+                {% endfor %}
+              </td>
+            {% else %}
+              <td class="replaced-by" markdown="1">
+                <p class="text-muted">(no replacement)</p>
+              </td>
+            {% endif %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    </div>
+  {% endif %}
+  <h2>{{ rules.removed.name }}</h2>
+  {{ rules.removed.description }}
+  <div class="rule-list removed-rules">
+  <table class="table table-striped">
+    <colgroup>
+      <col class="name" />
+      <col class="replaced-by" />
+    </colgroup>
+    <thead>
+      <tr>
+        <th>Removed rule</th>
+        <th>Replaced by</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for rule in rules.removed.rules %}
+        <tr>
+          <td markdown="1">
+            <a href="{{ rule.removed }}">{{ rule.removed }}</a>
+          </td>
+          {% if rule.replacedBy.size > 0 %}
+            <td class="replaced-by" markdown="1">
+              {% for replaced in rule.replacedBy %}
+               <a href="{{ replaced }}">{{ replaced }}</a>
+              {% endfor %}
+            </td>
+          {% else %}
+            <td class="replaced-by" markdown="1">
+              <p class="text-muted">(no replacement)</p>
+            </td>
+          {% endif %}
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/docs/6.0.0/rules/no-constructor-return.md
+++ b/docs/6.0.0/rules/no-constructor-return.md
@@ -1,0 +1,67 @@
+---
+title: no-constructor-return - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/no-constructor-return.md
+rule_type: problem
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# Disallow returning value in constructor (no-constructor-return)
+
+In JavaScript, returning a value in the constructor of a class may be a mistake. Forbidding this pattern prevents mistakes resulting from unfamiliarity with the language or a copy-paste error.
+
+## Rule Details
+
+This rule disallows return statements in the constructor of a class. Note that returning nothing with flow control is allowed.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-constructor-return: "error"*/
+
+class A {
+    constructor(a) {
+        this.a = a;
+        return a;
+    }
+}
+
+class B {
+    constructor(f) {
+        if (!f) {
+            return 'falsy';
+        }
+    }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-constructor-return: "error"*/
+
+class C {
+    constructor(c) {
+        this.c = c;
+    }
+}
+
+class D {
+    constructor(f) {
+        if (!f) {
+            return;  // Flow control.
+        }
+
+        f();
+    }
+}
+```
+
+## Version
+
+This rule was introduced in ESLint 6.7.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/no-constructor-return.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/no-constructor-return.md)

--- a/docs/6.0.0/rules/no-dupe-else-if.md
+++ b/docs/6.0.0/rules/no-dupe-else-if.md
@@ -1,0 +1,195 @@
+---
+title: no-dupe-else-if - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/no-dupe-else-if.md
+rule_type: problem
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# Disallow duplicate conditions in `if-else-if` chains (no-dupe-else-if)
+
+`if-else-if` chains are commonly used when there is a need to execute only one branch (or at most one branch) out of several possible branches, based on certain conditions.
+
+```js
+if (a) {
+    foo();
+} else if (b) {
+    bar();
+} else if (c) {
+    baz();
+}
+```
+
+Two identical test conditions in the same chain are almost always a mistake in the code. Unless there are side effects in the expressions, a duplicate will evaluate to the same `true` or `false` value as the identical expression earlier in the chain, meaning that its branch can never execute.
+
+```js
+if (a) {
+    foo();
+} else if (b) {
+    bar();
+} else if (b) {
+    baz();
+}
+```
+
+In the above example, `baz()` can never execute. Obviously, `baz()` could be executed only when `b` evaluates to `true`, but in that case `bar()` would be executed instead, since it's earlier in the chain.
+
+## Rule Details
+
+This rule disallows duplicate conditions in the same `if-else-if` chain.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-dupe-else-if: "error"*/
+
+if (isSomething(x)) {
+    foo();
+} else if (isSomething(x)) {
+    bar();
+}
+
+if (a) {
+    foo();
+} else if (b) {
+    bar();
+} else if (c && d) {
+    baz();
+} else if (c && d) {
+    quux();
+} else {
+    quuux();
+}
+
+if (n === 1) {
+    foo();
+} else if (n === 2) {
+    bar();
+} else if (n === 3) {
+    baz();
+} else if (n === 2) {
+    quux();
+} else if (n === 5) {
+    quuux();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-dupe-else-if: "error"*/
+
+if (isSomething(x)) {
+    foo();
+} else if (isSomethingElse(x)) {
+    bar();
+}
+
+if (a) {
+    foo();
+} else if (b) {
+    bar();
+} else if (c && d) {
+    baz();
+} else if (c && e) {
+    quux();
+} else {
+    quuux();
+}
+
+if (n === 1) {
+    foo();
+} else if (n === 2) {
+    bar();
+} else if (n === 3) {
+    baz();
+} else if (n === 4) {
+    quux();
+} else if (n === 5) {
+    quuux();
+}
+```
+
+This rule can also detect some cases where the conditions are not identical, but the branch can never execute due to the logic of `||` and `&&` operators.
+
+Examples of additional **incorrect** code for this rule:
+
+```js
+/*eslint no-dupe-else-if: "error"*/
+
+if (a || b) {
+    foo();
+} else if (a) {
+    bar();
+}
+
+if (a) {
+    foo();
+} else if (b) {
+    bar();
+} else if (a || b) {
+    baz();
+}
+
+if (a) {
+    foo();
+} else if (a && b) {
+    bar();
+}
+
+if (a && b) {
+    foo();
+} else if (a && b && c) {
+    bar();
+}
+
+if (a || b) {
+    foo();
+} else if (b && c) {
+    bar();
+}
+
+if (a) {
+    foo();
+} else if (b && c) {
+    bar();
+} else if (d && (c && e && b || a)) {
+    baz();
+}
+```
+
+Please note that this rule does not compare conditions from the chain with conditions inside statements, and will not warn in the cases such as follows:
+
+```js
+if (a) {
+    if (a) {
+        foo();
+    }
+}
+
+if (a) {
+    foo();
+} else {
+    if (a) {
+        bar();
+    }
+}
+```
+
+## When Not To Use It
+
+In rare cases where you really need identical test conditions in the same chain, which necessarily means that the expressions in the chain are causing and relying on side effects, you will have to turn this rule off.
+
+## Related Rules
+
+* [no-duplicate-case](no-duplicate-case)
+* [no-lonely-if](no-lonely-if)
+
+## Version
+
+This rule was introduced in ESLint 6.7.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/no-dupe-else-if.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/no-dupe-else-if.md)

--- a/docs/6.0.0/rules/no-import-assign.md
+++ b/docs/6.0.0/rules/no-import-assign.md
@@ -1,0 +1,61 @@
+---
+title: no-import-assign - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/no-import-assign.md
+rule_type: problem
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# disallow assigning to imported bindings (no-import-assign)
+
+The updates of imported bindings by ES Modules cause runtime errors.
+
+## Rule Details
+
+This rule warns the assignments, increments, and decrements of imported bindings.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-import-assign: "error"*/
+
+import mod, { named } from "./mod.mjs"
+import * as mod_ns from "./mod.mjs"
+
+mod = 1          // ERROR: 'mod' is readonly.
+named = 2        // ERROR: 'named' is readonly.
+mod_ns.named = 3 // ERROR: the members of 'mod_ns' is readonly.
+mod_ns = {}      // ERROR: 'mod_ns' is readonly.
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-import-assign: "error"*/
+
+import mod, { named } from "./mod.mjs"
+import * as mod_ns from "./mod.mjs"
+
+mod.prop = 1
+named.prop = 2
+mod_ns.named.prop = 3
+
+// Known Limitation
+function test(obj) {
+    obj.named = 4 // Not errored because 'obj' is not namespace objects.
+}
+test(mod_ns) // Not errored because it doesn't know that 'test' updates the member of the argument.
+```
+
+## When Not To Use It
+
+If you don't want to be notified about modifying imported bindings, you can disable this rule.
+
+## Version
+
+This rule was introduced in ESLint 6.4.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/no-import-assign.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/no-import-assign.md)

--- a/docs/6.0.0/rules/no-setter-return.md
+++ b/docs/6.0.0/rules/no-setter-return.md
@@ -1,0 +1,118 @@
+---
+title: no-setter-return - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/no-setter-return.md
+rule_type: problem
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# Disallow returning values from setters (no-setter-return)
+
+Setters cannot return values.
+
+While returning a value from a setter does not produce an error, the returned value is being ignored. Therefore, returning a value from a setter is either unnecessary or a possible error, since the returned value cannot be used.
+
+## Rule Details
+
+This rule disallows returning values from setters and reports `return` statements in setter functions.
+
+Only `return` without a value is allowed, as it's a control flow statement.
+
+This rule checks setters in:
+
+* Object literals.
+* Class declarations and class expressions.
+* Property descriptors in `Object.create`, `Object.defineProperty`, `Object.defineProperties`, and `Reflect.defineProperty` methods of the global objects.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-setter-return: "error"*/
+
+var foo = {
+    set a(value) {
+        this.val = value;
+        return value;
+    }
+};
+
+class Foo {
+    set a(value) {
+        this.val = value * 2;
+        return this.val;
+    }
+}
+
+const Bar = class {
+    static set a(value) {
+        if (value < 0) {
+            this.val = 0;
+            return 0;
+        }
+        this.val = value;
+    }
+};
+
+Object.defineProperty(foo, "bar", {
+    set(value) {
+        if (value < 0) {
+            return false;
+        }
+        this.val = value;
+    }
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-setter-return: "error"*/
+
+var foo = {
+    set a(value) {
+        this.val = value;
+    }
+};
+
+class Foo {
+    set a(value) {
+        this.val = value * 2;
+    }
+}
+
+const Bar = class {
+    static set a(value) {
+        if (value < 0) {
+            this.val = 0;
+            return;
+        }
+        this.val = value;
+    }
+};
+
+Object.defineProperty(foo, "bar", {
+    set(value) {
+        if (value < 0) {
+            throw new Error("Negative value.");
+        }
+        this.val = value;
+    }
+});
+```
+
+## Further Reading
+
+* [MDN setter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set)
+
+## Related Rules
+
+* [getter-return](getter-return)
+
+## Version
+
+This rule was introduced in ESLint 6.7.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/no-setter-return.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/no-setter-return.md)

--- a/docs/6.0.0/rules/prefer-exponentiation-operator.md
+++ b/docs/6.0.0/rules/prefer-exponentiation-operator.md
@@ -1,0 +1,65 @@
+---
+title: prefer-exponentiation-operator - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/prefer-exponentiation-operator.md
+rule_type: suggestion
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# Disallow the use of `Math.pow` in favor of the `**` operator (prefer-exponentiation-operator)
+
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+Introduced in ES2016, the infix exponentiation operator `**` is an alternative for the standard `Math.pow` function.
+
+Infix notation is considered to be more readable and thus more preferable than the function notation.
+
+## Rule Details
+
+This rule disallows calls to `Math.pow` and suggests using the `**` operator instead.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint prefer-exponentiation-operator: "error"*/
+
+const foo = Math.pow(2, 8);
+
+const bar = Math.pow(a, b);
+
+let baz = Math.pow(a + b, c + d);
+
+let quux = Math.pow(-1, n);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint prefer-exponentiation-operator: "error"*/
+
+const foo = 2 ** 8;
+
+const bar = a ** b;
+
+let baz = (a + b) ** (c + d);
+
+let quux = (-1) ** n;
+```
+
+## When Not To Use It
+
+This rule should not be used unless ES2016 is supported in your codebase.
+
+## Further Reading
+
+* [MDN Arithmetic Operators - Exponentiation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation)
+* [Issue 5848: Exponentiation operator ** has different results for numbers and variables from 50 upwards](https://bugs.chromium.org/p/v8/issues/detail?id=5848)
+
+## Version
+
+This rule was introduced in ESLint 6.7.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/prefer-exponentiation-operator.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/prefer-exponentiation-operator.md)

--- a/docs/6.0.0/rules/prefer-regex-literals.md
+++ b/docs/6.0.0/rules/prefer-regex-literals.md
@@ -1,0 +1,107 @@
+---
+title: prefer-regex-literals - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/prefer-regex-literals.md
+rule_type: suggestion
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# Disallow use of the `RegExp` constructor in favor of regular expression literals (prefer-regex-literals)
+
+There are two ways to create a regular expression:
+
+* Regular expression literals, e.g., `/abc/u`.
+* The `RegExp` constructor function, e.g., `new RegExp("abc", "u")` or `RegExp("abc", "u")`.
+
+The constructor function is particularly useful when you want to dynamically generate the pattern,
+because it takes string arguments.
+
+When using the constructor function with string literals, don't forget that the string escaping rules still apply.
+If you want to put a backslash in the pattern, you need to escape it in the string literal.
+Thus, the following are equivalent:
+
+```js
+new RegExp("^\\d\\.$");
+
+/^\d\.$/;
+
+// matches "0.", "1.", "2." ... "9."
+```
+
+In the above example, the regular expression literal is easier to read and reason about.
+Also, it's a common mistake to omit the extra `\` in the string literal, which would produce a completely different regular expression:
+
+```js
+new RegExp("^\d\.$");
+
+// equivalent to /^d.$/, matches "d1", "d2", "da", "db" ...
+```
+
+When a regular expression is known in advance, it is considered a best practice to avoid the string literal notation on top
+of the regular expression notation, and use regular expression literals instead of the constructor function.
+
+## Rule Details
+
+This rule disallows the use of the `RegExp` constructor function with string literals as its arguments.
+
+This rule also disallows the use of the `RegExp` constructor function with template literals without expressions
+and `String.raw` tagged template literals without expressions.
+
+The rule does not disallow all use of the `RegExp` constructor. It should be still used for
+dynamically generated regular expressions.
+
+Examples of **incorrect** code for this rule:
+
+```js
+new RegExp("abc");
+
+new RegExp("abc", "u");
+
+RegExp("abc");
+
+RegExp("abc", "u");
+
+new RegExp("\\d\\d\\.\\d\\d\\.\\d\\d\\d\\d");
+
+RegExp(`^\\d\\.$`);
+
+new RegExp(String.raw`^\d\.$`);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/abc/;
+
+/abc/u;
+
+/\d\d\.\d\d\.\d\d\d\d/;
+
+/^\d\.$/;
+
+// RegExp constructor is allowed for dynamically generated regular expressions
+
+new RegExp(pattern);
+
+RegExp("abc", flags);
+
+new RegExp(prefix + "abc");
+
+RegExp(`${prefix}abc`);
+
+new RegExp(String.raw`^\d\. ${sufix}`);
+```
+
+## Further Reading
+
+* [MDN: Regular Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
+* [MDN: RegExp Constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+
+## Version
+
+This rule was introduced in ESLint 6.4.0.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/prefer-regex-literals.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/prefer-regex-literals.md)

--- a/docs/7.0.0/user-guide/configuring.md
+++ b/docs/7.0.0/user-guide/configuring.md
@@ -812,7 +812,7 @@ The `rules` property can do any of the following to extend (or override) the set
 
 ### Using `"eslint:recommended"`
 
-An `extends` property value `"eslint:recommended"` enables a subset of core rules that report common problems, which have a check mark (recommended) on the [rules page](../rules/). The recommended subset can change only at major versions of ESLint.
+An `extends` property value `"eslint:recommended"` enables a subset of core rules that report common problems, which have a check mark (recommended) on the [rules page](/docs/rules/). The recommended subset can change only at major versions of ESLint.
 
 If your configuration extends the recommended rules: after you upgrade to a newer major version of ESLint, review the reported problems before you use the `--fix` option on the [command line](./command-line-interface#fix), so you know if a new fixable recommended rule will make changes to the code.
 

--- a/docs/maintainer-guide/governance.md
+++ b/docs/maintainer-guide/governance.md
@@ -26,9 +26,9 @@ Contributors have read-only access to source code and so submit changes via pull
 
 As Contributors gain experience and familiarity with the project, their profile within, and commitment to, the community will increase. At some stage, they may find themselves being nominated for committership by an existing Committer.
 
-### Committers
+### Committersd
 
-Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Committers are given push access to the project's GitHub repos and must abide by the project's [Contribution Guidelines](contributing).
+Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Committers are given push access to the project's GitHub repos and must abide by the project's [Contribution Guidelines](../developer-guide/contributing).
 
 Committers:
 

--- a/docs/maintainer-guide/governance.md
+++ b/docs/maintainer-guide/governance.md
@@ -26,7 +26,7 @@ Contributors have read-only access to source code and so submit changes via pull
 
 As Contributors gain experience and familiarity with the project, their profile within, and commitment to, the community will increase. At some stage, they may find themselves being nominated for committership by an existing Committer.
 
-### Committersd
+### Committers
 
 Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Committers are given push access to the project's GitHub repos and must abide by the project's [Contribution Guidelines](../developer-guide/contributing).
 


### PR DESCRIPTION
Since the docs for previous versions do not exist in the master branch of the eslint repo, it seemed that the links should be updated in the website repo.  I originally thought otherwise.  That is why this is a 2nd PR for the same issue.

This should resolve all broken links that were originally reported in #668.

Notable Notes:

The content of `/docs/user-guide/formatters/` from the v4.19.1 tag has been copied and pasted to `/docs/4.0.0/user-guide/formatters/`.

The content of `/docs/rules/index.md` from the v5.16.0 tag has been copied and pasted to `/docs/5.0.0/rules/index.md`.

The content of `/docs/rules/index.liquid` from the v6.8.0 tag has been copied and pasted to `/docs/6.0.0/rules/index.liquid`.  This caused new broken links to rules that don't seem to exist in `/docs/6.0.0/rules/`...  list is below:

Found in v6.8 and copy/pasted in to the v6 rules folder:
```
http://localhost:8080/docs/6.0.0/rules/no-dupe-else-if
http://localhost:8080/docs/6.0.0/rules/no-import-assign
http://localhost:8080/docs/6.0.0/rules/no-setter-return
http://localhost:8080/docs/6.0.0/rules/default-param-last
http://localhost:8080/docs/6.0.0/rules/grouped-accessor-pairs
http://localhost:8080/docs/6.0.0/rules/no-constructor-return
http://localhost:8080/docs/6.0.0/rules/prefer-regex-literals
http://localhost:8080/docs/6.0.0/rules/function-call-argument-newline
http://localhost:8080/docs/6.0.0/rules/prefer-exponentiation-operator
```

Not found in v6.8 and still broken:
```
http://localhost:8080/docs/6.0.0/rules/no-useless-backreference
http://localhost:8080/docs/6.0.0/rules/default-case-last
http://localhost:8080/docs/6.0.0/rules/no-restricted-exports
```

In addition to the 3 mentioned directly above, the only other "broken link" I see is `http://localhost:8080/docs/2.0.0/developer-guide/code-path-analysis.html` and I believe it is from the Twitter head tag.  Perhaps some other level would fix that?