### PR TITLE
Update: Copyright notice JS Foundation to OpenJS Foundation

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -9,10 +9,13 @@
       {% endif %}
       <li><a href="https://groups.google.com/group/eslint">Mailing List</a></li>
       <li><a href="https://github.com/eslint/eslint">GitHub</a></li>
+
       <li><a href="https://twitter.com/geteslint">Twitter</a></li>
       <li><a href="https://gitter.im/eslint/eslint">Chat Room</a></li>
-      <li>Copyright OpenJS Foundation and other contributors, <a href="https://openjsf.org/">https://openjsf.org/</a></li>
+
     </ul>
+    <p>Copyright <a href="https://openjsf.org">OpenJS Foundation</a> and ESLint contributors. All rights reserved. The <a href="https://openjsf.org">OpenJS Foundation</a> has registered trademarks and uses trademarks.  For a list of trademarks of the <a href="https://openjsf.org">OpenJS Foundation</a>, please see our <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> and <a href="https://trademark-list.openjsf.org">Trademark List</a>.  Node.js is a trademark of Joyent, Inc. and is used with its permission. Trademarks and logos not indicated on the <a href="https://trademark-list.openjsf.org">list of OpenJS Foundation trademarks</a> are trademarks&trade; or registered&reg; trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.</p>
+    <p><a href="https://openjsf.org">The OpenJS Foundation</a> | <a href="https://terms-of-use.openjsf.org">Terms of Use</a> | <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> | <a href="https://bylaws.openjsf.org">OpenJS Foundation Bylaws</a> | <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> | <a href="https://trademark-list.openjsf.org">Trademark List</a> | <a href="https://www.linuxfoundation.org/cookies">Cookie Policy</a></p>
   </footer>
 </div>
 <script src="/assets/js/main.js"></script>

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -11,7 +11,7 @@
       <li><a href="https://github.com/eslint/eslint">GitHub</a></li>
       <li><a href="https://twitter.com/geteslint">Twitter</a></li>
       <li><a href="https://gitter.im/eslint/eslint">Chat Room</a></li>
-      <li>Copyright JS Foundation and other contributors, <a href="https://js.foundation">https://js.foundation/</a></li>
+      <li>Copyright OpenJS Foundation and other contributors, <a href="https://openjsf.org/">https://openjsf.org/</a></li>
     </ul>
   </footer>
 </div>


### PR DESCRIPTION
The JS Foundation merged with Node.js Foundation to form OpenJS. ESLint is listed on https://openjsf.org/projects/ as an At-Large Project.

* Update footer.liquid with standard footer from IP Policy guidance