### PR TITLE
Docs: improve documentation of no-return-await

### DIFF
--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -8,7 +8,9 @@ rule_type: suggestion
 
 # Disallows unnecessary `return await` (no-return-await)
 
-Inside an `async function`, `return await` is seldom useful. Since the return value of an `async function` is always wrapped in `Promise.resolve`, `return await` doesn’t actually do anything except add extra time before the overarching Promise resolves or rejects. The only valid exception is if `return await` is used in a try/catch statement to catch errors from another Promise-based function.
+Using `return await` inside an `async function`keeps the current function in the call stack until the Promise that is being awaited have resolved. You can take a shortcut and just return the `Promise` right away to avoid this, saving an extra microtask before resolving the overarching Promise.
+
+The only visible change when doing this is that the function will no longer be a part of the stack trace, if an error is thrown asyncrously from the Promise being returned.
 
 ## Rule Details
 
@@ -50,7 +52,11 @@ In the last example the `await` is necessary to be able to catch errors thrown f
 
 ## When Not To Use It
 
-If you want to use `await` to denote a value that is a thenable, even when it is not necessary; or if you do not want the performance benefit of avoiding `return await`, you can turn off this rule.
+There are a few reasons you might want to turn this rule off:
+
+- If you want to use `await` to denote a value that is a thenable
+- If you do not want the performance benefit of avoiding `return await`
+- If you still want the functions to show up in stack traces
 
 ## Further Reading
 


### PR DESCRIPTION
First of all, I know that there have been a lot of discussions on wether this rule is a good one or not. I do not want to bring up that discussion here at all. I just want to clarify the documentation to better explain the implications, I don't want to advocate for either turning this rule on or off.

-----

I've had some team member asking why we are using `return await`, especially after reading the current version of the documentation for `no-return-await`. The reason we are using `return await` is because otherwise the functions are missing from the stack traces if an error is thrown asynchronously in the promise that is being returned.

My intention with this change is to document that pitfall, and to clarify exactly what is being skipped when not using `return await` (that is, that the function is either still on the call stack, or not)

I'm very open to suggestion on more improvements that we can do here! ❤️ 