### PR TITLE
chore: Correct examples for no-param-reassign

### DIFF
--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -137,15 +137,15 @@ Examples of **correct** code for the `{ "props": true }` option with `"ignorePro
 ```js
 /*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsForRegex": ["^bar"] }]*/
 
-function foo(bar) {
+function foo(barVar) {
     barVar.prop = "value";
 }
 
-function foo(bar) {
+function foo(barrito) {
     delete barrito.aaa;
 }
 
-function foo(bar) {
+function foo(bar_) {
     bar_.aaa++;
 }
 ```


### PR DESCRIPTION
Specifically for parameter "ignorePropertyModificationsForRegex"