### PR TITLE
Fix: use forced redirects in _redirects file

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -6,7 +6,7 @@ https://eslint.netlify.com/* https://eslint.org/:splat 301!
 
 /docs                               / 301!
 /docs/user-guide/rules              /docs/rules 301!
-/cla                                https://cla.js.foundation/eslint/eslint 301!
+/cla                                https://cla.js.foundation/eslint/eslint 302!
 
 /docs/0.24.1/command-line-interface /docs/user-guide/command-line-interface 301!
 /docs/0.24.1/configuring            /docs/user-guide/configuring 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -4,33 +4,33 @@
 # Redirect default Netlify subdomain to primary domain
 https://eslint.netlify.com/* https://eslint.org/:splat 301!
 
-/docs                               /
-/docs/user-guide/rules              /docs/rules
-/cla                                https://cla.js.foundation/eslint/eslint
+/docs                               / 301!
+/docs/user-guide/rules              /docs/rules 301!
+/cla                                https://cla.js.foundation/eslint/eslint 301!
 
-/docs/0.24.1/command-line-interface /docs/user-guide/command-line-interface
-/docs/0.24.1/configuring            /docs/user-guide/configuring
-/docs/0.24.1/integrations           /docs/integrations
-/docs/0.24.1/user-guide/rules       /docs/rules
+/docs/0.24.1/command-line-interface /docs/user-guide/command-line-interface 301!
+/docs/0.24.1/configuring            /docs/user-guide/configuring 301!
+/docs/0.24.1/integrations           /docs/integrations 301!
+/docs/0.24.1/user-guide/rules       /docs/rules 301!
 
-/docs/1.0.0/command-line-interface  /docs/user-guide/command-line-interface
-/docs/1.0.0/configuring             /docs/user-guide/configuring
-/docs/1.0.0/integrations            /docs/integrations
-/docs/1.0.0/user-guide/rules        /docs/rules
+/docs/1.0.0/command-line-interface  /docs/user-guide/command-line-interface 301!
+/docs/1.0.0/configuring             /docs/user-guide/configuring 301!
+/docs/1.0.0/integrations            /docs/integrations 301!
+/docs/1.0.0/user-guide/rules        /docs/rules 301!
 
-/docs/1.10.3/command-line-interface /docs/user-guide/command-line-interface
-/docs/1.10.3/configuring            /docs/user-guide/configuring
-/docs/1.10.3/integrations           /docs/integrations
-/docs/1.10.3/user-guide/rules       /docs/rules
+/docs/1.10.3/command-line-interface /docs/user-guide/command-line-interface 301!
+/docs/1.10.3/configuring            /docs/user-guide/configuring 301!
+/docs/1.10.3/integrations           /docs/integrations 301!
+/docs/1.10.3/user-guide/rules       /docs/rules 301!
 
-/docs/2.0.0/command-line-interface  /docs/user-guide/command-line-interface
-/docs/2.0.0/configuring             /docs/user-guide/configuring
-/docs/2.0.0/integrations            /docs/integrations
-/docs/2.0.0/user-guide/rules        /docs/rules
+/docs/2.0.0/command-line-interface  /docs/user-guide/command-line-interface 301!
+/docs/2.0.0/configuring             /docs/user-guide/configuring 301!
+/docs/2.0.0/integrations            /docs/integrations 301!
+/docs/2.0.0/user-guide/rules        /docs/rules 301!
 
-/docs/2.13.1/command-line-interface /docs/user-guide/command-line-interface
-/docs/2.13.1/configuring            /docs/user-guide/configuring
-/docs/2.13.1/integrations           /docs/integrations
-/docs/2.13.1/user-guide/rules       /docs/rules
+/docs/2.13.1/command-line-interface /docs/user-guide/command-line-interface 301!
+/docs/2.13.1/configuring            /docs/user-guide/configuring 301!
+/docs/2.13.1/integrations           /docs/integrations 301!
+/docs/2.13.1/user-guide/rules       /docs/rules 301!
 
-/docs/3.0.0/user-guide/rules        /docs/rules
+/docs/3.0.0/user-guide/rules        /docs/rules 301!


### PR DESCRIPTION
This PR fixes the redirects that were broken by [the bug fix](https://community.netlify.com/t/changed-behavior-in-redirects/10084) that Netlify implemented. I had been planning to do it before the deadline but then got sick - apologies that it's a bit late. I think marking all of these as forced redirects makes sense since we never want it to follow the shadowing behavior for the existing redirects.