### PR TITLE
Fix: remove empty Node.js and CommonJS category

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -562,10 +562,6 @@ categories:
         name: no-use-before-define
         recommended: false
   - description: >-
-      These rules relate to code running in Node.js, or in browsers with
-      CommonJS:
-    name: Node.js and CommonJS
-  - description: >-
       These rules relate to style guidelines, and are therefore quite
       subjective:
     name: Stylistic Issues


### PR DESCRIPTION
Following up on https://github.com/eslint/eslint/pull/13242 and https://github.com/eslint/eslint/pull/13230, this removes the empty `Node.js and CommonJS` category on the [rules page](https://eslint.org/docs/rules/#node-js-and-commonjs).