### PR TITLE
Fix: update foundation name in footer

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -11,7 +11,7 @@
       <li><a href="https://github.com/eslint/eslint">GitHub</a></li>
       <li><a href="https://twitter.com/geteslint">Twitter</a></li>
       <li><a href="https://gitter.im/eslint/eslint">Chat Room</a></li>
-      <li>Copyright JS Foundation and other contributors, <a href="https://js.foundation">https://js.foundation/</a></li>
+      <li>Copyright OpenJS Foundation and other contributors, <a href="https://openjsf.org/">https://openjsf.org/</a></li>
     </ul>
   </footer>
 </div>


### PR DESCRIPTION
While working on https://github.com/eslint/website/pull/720, I noticed that we still have the JS Foundation listed in our footer. Note that the current link does redirect correctly.