### PR TITLE
Docs: Add v7 migration guide to header menu

### DIFF
--- a/_includes/menu.liquid
+++ b/_includes/menu.liquid
@@ -26,13 +26,13 @@
             <li><a href="/docs/user-guide/formatters">Formatters</a></li>
             <li><a href="/docs/user-guide/integrations">Integrations</a></li>
             <li class="divider"></li>
-            <li><a href="/docs/user-guide/migrating-to-1.0.0">Migrating to v1.0.0</a></li>
-            <li><a href="/docs/user-guide/migrating-to-2.0.0">Migrating to v2.0.0</a></li>
-            <li><a href="/docs/user-guide/migrating-to-3.0.0">Migrating to v3.0.0</a></li>
-            <li><a href="/docs/user-guide/migrating-to-4.0.0">Migrating to v4.0.0</a></li>
-            <li><a href="/docs/user-guide/migrating-to-5.0.0">Migrating to v5.0.0</a></li>
-            <li><a href="/docs/user-guide/migrating-to-6.0.0">Migrating to v6.0.0</a></li>
             <li><a href="/docs/user-guide/migrating-to-7.0.0">Migrating to v7.0.0</a></li>
+            <li><a href="/docs/user-guide/migrating-to-6.0.0">Migrating to v6.0.0</a></li>
+            <li><a href="/docs/user-guide/migrating-to-5.0.0">Migrating to v5.0.0</a></li>
+            <li><a href="/docs/user-guide/migrating-to-4.0.0">Migrating to v4.0.0</a></li>
+            <li><a href="/docs/user-guide/migrating-to-3.0.0">Migrating to v3.0.0</a></li>
+            <li><a href="/docs/user-guide/migrating-to-2.0.0">Migrating to v2.0.0</a></li>
+            <li><a href="/docs/user-guide/migrating-to-1.0.0">Migrating to v1.0.0</a></li>
             <li><a href="/docs/user-guide/migrating-from-jscs">Migrating from JSCS</a></li>
           </ul>
         </li>

--- a/_includes/menu.liquid
+++ b/_includes/menu.liquid
@@ -32,6 +32,7 @@
             <li><a href="/docs/user-guide/migrating-to-4.0.0">Migrating to v4.0.0</a></li>
             <li><a href="/docs/user-guide/migrating-to-5.0.0">Migrating to v5.0.0</a></li>
             <li><a href="/docs/user-guide/migrating-to-6.0.0">Migrating to v6.0.0</a></li>
+            <li><a href="/docs/user-guide/migrating-to-7.0.0">Migrating to v7.0.0</a></li>
             <li><a href="/docs/user-guide/migrating-from-jscs">Migrating from JSCS</a></li>
           </ul>
         </li>


### PR DESCRIPTION
Now that we have 7 migration guides in the menu, what do y'all think of putting them in descending order so the most recent version's guide will be listed first?