### PR TITLE
Fix: don't render links when plugin replaces core rule

### DIFF
--- a/docs/rules/index.liquid
+++ b/docs/rules/index.liquid
@@ -50,17 +50,22 @@ layout: doc
             <td markdown="1">
               <a href="{{ rule.name }}">{{ rule.name }}</a>
             </td>
-            {% if rule.replacedBy.size > 0 %}
-              <td class="replaced-by" markdown="1">
-                {% for replaced in rule.replacedBy %}
-                <a href="{{ replaced }}">{{ replaced }}</a>
-                {% endfor %}
-              </td>
-            {% else %}
-              <td class="replaced-by" markdown="1">
-                <p class="text-muted">(no replacement)</p>
-              </td>
-            {% endif %}
+            <td class="replaced-by" markdown="1">
+              {% assign hasReplacement = false %}
+              {% if rule.replacedBy.size > 0 %}
+                  {% for replaced in rule.replacedBy %}
+                    {% comment %} Do not link to rule docs in 3rd party plugins. {% endcomment %}
+                    {% assign ruleNameSegments = replaced | split: "/" %}
+                    {% if ruleNameSegments.size == 1 %}
+                      <a href="{{ replaced }}">{{ replaced }}</a>
+                      {% assign hasReplacement = true %}
+                    {% endif %}
+                  {% endfor %}
+              {% endif %}
+              {% if hasReplacement == false %}
+                  <p class="text-muted">(no replacement)</p>
+              {% endif %}
+            </td>
           </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
Fun with programming in Liquid! The [deprecated rules](https://eslint.org/docs/rules/#deprecated) currently link to broken links. To avoid having to keep track of 3rd party plugins, we can just not render namespaced rules.

For consistency, I will also follow up with a PR that removes these `replacedBy` fields in the deprecated Node.js/CommonJS rules to match what we did with the deprecated JSDoc rules.

**Edit**
Follow up PR: https://github.com/eslint/eslint/pull/13274