### PR TITLE
Docs: Change Markdown code fence to <code> tag

### DIFF
--- a/docs/rules/index.liquid
+++ b/docs/rules/index.liquid
@@ -6,7 +6,7 @@ layout: doc
 <h1>Rules</h1>
 <p>Rules in ESLint are grouped by category to help you understand their purpose.</p>
 <p>No rules are enabled by default. The <code>"extends": "eslint:recommended"</code> property in a <a href="../user-guide/configuring#extending-configuration-files">configuration file</a> enables rules that report common problems, which have a check mark (recommended) below.</p>
-<p>The `--fix` option on the <a href="../user-guide/command-line-interface#fix">command line</a> automatically fixes problems (currently mostly whitespace) reported by rules which have a wrench (fixable) below.</p>
+<p>The <code>--fix</code> option on the <a href="../user-guide/command-line-interface#fix">command line</a> automatically fixes problems (currently mostly whitespace) reported by rules which have a wrench (fixable) below.</p>
 {% for category in rules.categories %}
   <h2>{{ category.name }}</h2>
   {{ category.description }}


### PR DESCRIPTION
The current version is rendering the raw backticks.