### PR TITLE
Update: Code of conduct redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -7,6 +7,7 @@ https://eslint.netlify.com/* https://eslint.org/:splat 301!
 /docs                               / 301!
 /docs/user-guide/rules              /docs/rules 301!
 /cla                                https://cla.js.foundation/eslint/eslint 302!
+/conduct                            https://code-of-conduct.openjsf.org/ 302!
 
 /docs/0.24.1/command-line-interface /docs/user-guide/command-line-interface 301!
 /docs/0.24.1/configuring            /docs/user-guide/configuring 301!


### PR DESCRIPTION
This adds a redirect for /conduct that forwards to the OpenJS Foundation Code of Conduct. This is for convenience purposes in case the CoC changes location again. 