### PR TITLE
Update: Switch chat links to Discord (refs eslint/eslint#13029)

### DIFF
--- a/_data/site.js
+++ b/_data/site.js
@@ -17,5 +17,12 @@ function calculateUrl() {
 module.exports = {
     title: "ESLint - Pluggable JavaScript linter",
     description: "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease.",
-    url: calculateUrl()
+    url: calculateUrl(),
+    links: {
+        chat: "/chat",
+        codeOfConduct: "/conduct",
+        mailingList: "https://groups.google.com/group/eslint",
+        github: "https://github.com/eslint/eslint",
+        twitter: "https://twitter.com/geteslint"
+    }
 };

--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -7,10 +7,10 @@
       {% else %}
         <li><a href="https://github.com/eslint/website/edit/master/{{ page.inputPath }}">Edit this page</a></li>
       {% endif %}
-      <li><a href="https://groups.google.com/group/eslint">Mailing List</a></li>
-      <li><a href="https://github.com/eslint/eslint">GitHub</a></li>
-      <li><a href="https://twitter.com/geteslint">Twitter</a></li>
-      <li><a href="https://gitter.im/eslint/eslint">Chat Room</a></li>
+      <li><a href="{{ site.links.mailingList }}">Mailing List</a></li>
+      <li><a href="{{ site.links.github }}">GitHub</a></li>
+      <li><a href="{{ site.links.twitter }}">Twitter</a></li>
+      <li><a href="{{ site.links.chat }}">Chat Room</a></li>
       <li>Copyright OpenJS Foundation and other contributors, <a href="https://openjsf.org/">https://openjsf.org/</a></li>
     </ul>
   </footer>

--- a/docs/maintainer-guide/governance.md
+++ b/docs/maintainer-guide/governance.md
@@ -56,7 +56,7 @@ A Committer who shows an above-average level of contribution to the project, par
 1. Send email congratulating the new committer and confirming that they would like to accept. This should also outline the responsibilities of a committer with a link to the maintainer guide.
 1. Add the GitHub user to the "ESLint Team" team
 1. Add committer email to the ESLint team mailing list
-1. Invite to Gitter team chatroom
+1. Invite to Discord team chatroom
 1. Tweet congratulations to the new committer from the ESLint Twitter account
 
 ### Reviewers
@@ -121,7 +121,7 @@ A Reviewer is invited to become a TSC member by existing TSC members. A nominati
 1. Add the GitHub user to the "ESLint TSC" GitHub team
 1. Set the GitHub user to be have the "Owner" role for the ESLint organization
 1. Send a welcome email with a link to the [maintainer guide](./) and the [npm 2FA guide](./npm-2fa).
-1. Invite to the Gitter TSC chatroom
+1. Invite to the Discord TSC chatroom
 1. Make the TSC member an admin on the ESLint team mailing list
 1. Add the TSC member to the recurring TSC meeting event on Google Calendar
 1. Add the TSC member as an admin to ESLint Twitter Account on Tweetdeck

--- a/public/_redirects
+++ b/public/_redirects
@@ -4,10 +4,14 @@
 # Redirect default Netlify subdomain to primary domain
 https://eslint.netlify.com/* https://eslint.org/:splat 301!
 
-/docs                               / 301!
-/docs/user-guide/rules              /docs/rules 301!
+# External Redirects
 /cla                                https://cla.js.foundation/eslint/eslint 302!
 /conduct                            https://code-of-conduct.openjsf.org/ 302!
+/chat                               https://discord.gg/8szcydm 302!
+
+# Internal Redirects
+/docs                               / 301!
+/docs/user-guide/rules              /docs/rules 301!
 
 /docs/0.24.1/command-line-interface /docs/user-guide/command-line-interface 301!
 /docs/0.24.1/configuring            /docs/user-guide/configuring 301!


### PR DESCRIPTION
This switches all chatroom links from Gitter to Discord. Also centralized our social links to make them a bit easier to change later on.