### PR TITLE
Update: Add redirect for TSC meetings channel

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -7,6 +7,7 @@ https://eslint.netlify.com/* https://eslint.org/:splat 301!
 # External Redirects
 /cla                                https://cla.js.foundation/eslint/eslint 302!
 /conduct                            https://code-of-conduct.openjsf.org/ 302!
+/chat/tsc-meetings                  https://discord.gg/3brqTzJ 302!
 /chat                               https://discord.gg/8szcydm 302!
 
 # Internal Redirects


### PR DESCRIPTION
This adds a redirect to the #tsc-meetings channel on our Discord server (suitable for sharing with others).