### PR TITLE
Update: Add redirect for Discord help channel

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -8,6 +8,7 @@ https://eslint.netlify.com/* https://eslint.org/:splat 301!
 /cla                                https://cla.js.foundation/eslint/eslint 302!
 /conduct                            https://code-of-conduct.openjsf.org/ 302!
 /chat/tsc-meetings                  https://discord.gg/3brqTzJ 302!
+/chat/help                          https://discord.gg/nJdtBaF 302!
 /chat                               https://discord.gg/8szcydm 302!
 
 # Internal Redirects


### PR DESCRIPTION
This adds a redirect to the Discord #help channel. Hopefully if we include this in error messages we'll get fewer people showing up in #developers asking for help. (Also easier to share on Twitter)