### PR TITLE
Fix no-confusing-arrow example

### DIFF
--- a/docs/2.0.0/rules/no-confusing-arrow.md
+++ b/docs/2.0.0/rules/no-confusing-arrow.md
@@ -15,7 +15,7 @@ var x = a => 1 ? 2 : 3
 // Did the author mean this
 var x = function (a) { return a >= 1 ? 2 : 3 }
 // Or this
-var x = a <= 1 ? 2 : 3
+var x = a <= 1 ? 3 : 2
 ```
 
 ## Rule Details


### PR DESCRIPTION
The author certainly didn't mean `var x = a <= 1 ? 2 : 3`, because it's never equivalent to `var x = a => 1 ? 2 : 3`, even with suitable parentheses.