### PR TITLE
Fix: Ensure headings have IDs (fixes #747)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,14 +19,6 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addPassthroughCopy({ "public/*": "." });
     eleventyConfig.addPassthroughCopy("docs/**/*.svg");
 
-    // Replace the default Markdown engine with a new one that creates ID in headings
-    // See: https://github.com/eslint/website/issues/747
-    const markdownIt = require("markdown-it");
-    const markdownItAnchor = require("markdown-it-anchor");
-    const markdownLib = markdownIt({ html: true }).use(markdownItAnchor);
-
-    eleventyConfig.setLibrary("md", markdownLib);
-
     return {
         dir: {
             includes: "_includes",

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,6 +19,14 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addPassthroughCopy({ "public/*": "." });
     eleventyConfig.addPassthroughCopy("docs/**/*.svg");
 
+    // Replace the default Markdown engine with a new one that creates ID in headings
+    // See: https://github.com/eslint/website/issues/747
+    const markdownIt = require("markdown-it");
+    const markdownItAnchor = require("markdown-it-anchor");
+    const markdownLib = markdownIt({ html: true }).use(markdownItAnchor);
+
+    eleventyConfig.setLibrary("md", markdownLib);
+
     return {
         dir: {
             includes: "_includes",

--- a/_11ty/plugins/index.js
+++ b/_11ty/plugins/index.js
@@ -1,5 +1,5 @@
 "use strict";
 
 module.exports = {
-    syntaxHighlighting: require("./syntax-highlighting")
+    markdownPlugins: require("./markdown-plugins")
 };

--- a/_11ty/plugins/markdown-plugins.js
+++ b/_11ty/plugins/markdown-plugins.js
@@ -2,9 +2,12 @@
 
 const markdownIt = require("markdown-it");
 const highlightJS = require("highlight.js");
+const GitHubSlugger = require("github-slugger");
 
 module.exports = function syntaxHighlighting(eleventyConfig) {
-    const md = markdownIt({
+
+    const slugger = new GitHubSlugger();
+    let md = markdownIt({
 
         // https://github.com/markdown-it/markdown-it#syntax-highlighting
         highlight(text, lang = null) {
@@ -20,6 +23,23 @@ module.exports = function syntaxHighlighting(eleventyConfig) {
             return `<pre class="hljs highlight-${lang}"><code>${md.utils.escapeHtml(text)}</code></pre>`;
         },
         html: true
+    });
+
+    // Replace the default Markdown engine with a new one that creates ID in headings
+    // See: https://github.com/eslint/website/issues/747
+    md = md.use(require("markdown-it-anchor"), {
+        slugify(text) {
+
+            // need to replace all the characters GitHub replaces
+            return slugger.slug(text.replace(/[<>()[\]{}]/gu, ""))
+
+                // non-ASCII characters are a pain to fix
+                // first replace them all with dashes
+                .replace(/[^\u{00}-\u{FF}]/gu, "-")
+
+                // then replace all -- with -
+                .replace(/-+/gu, "-");
+        }
     });
 
     eleventyConfig.setLibrary("md", md);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2004,7 +2004,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -2652,7 +2652,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2689,7 +2689,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -3487,7 +3487,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -3500,7 +3500,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -3836,7 +3836,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -7442,6 +7442,12 @@
         "uc.micro": "^1.0.5"
       }
     },
+    "markdown-it-anchor": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
+      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+      "dev": true
+    },
     "maximatch": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
@@ -9863,7 +9869,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,6 +5933,23 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
+          "dev": true
+        }
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -6475,6 +6492,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
+    },
+    "innertext": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/innertext/-/innertext-1.0.3.tgz",
+      "integrity": "sha512-ZC410b7IbrTrmt8bQb27xUOJgXkJu+XL6MVncb9FGyxjRIHyQqNjpSDY20zvSUttkAiYj0dait/67/sXyWvwYg==",
+      "dev": true,
+      "requires": {
+        "html-entities": "^1.2.0"
+      }
     },
     "inquirer": {
       "version": "7.1.0",
@@ -7447,6 +7473,16 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
       "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
       "dev": true
+    },
+    "markdown-it-github-headings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-github-headings/-/markdown-it-github-headings-2.0.0.tgz",
+      "integrity": "sha512-7ET0QiS2UWCM4hZraWVT9Df0PzuTQwK//3XM1q8vtXImUCRNGwG4bapa6ToDL8M4jkPeYSMrTiTvdJqwJifC4Q==",
+      "dev": true,
+      "requires": {
+        "github-slugger": "^1.1.1",
+        "innertext": "^1.0.1"
+      }
     },
     "maximatch": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.20.0",
     "express": "^4.17.1",
+    "github-slugger": "^1.3.0",
     "html-entities": "^1.3.1",
     "html-minifier": "^4.0.0",
     "htmlparser2": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "less-loader": "^6.1.0",
     "less-plugin-clean-css": "^1.5.1",
     "luxon": "^1.24.1",
+    "markdown-it-anchor": "^5.3.0",
     "morgan": "^1.10.0",
     "node-fetch": "^2.6.0",
     "regenerator-runtime": "^0.13.5",


### PR DESCRIPTION
This adds the `markdown-it-anchor` plugin to the default Markdown generator in order to generate IDs for all headings in the site. This change will fix the issue we're having with Algolia search.