### PR TITLE
Fix: fetch only incoming orders from Open Collective in fetch-sponsors

### DIFF
--- a/_data/sponsors.json
+++ b/_data/sponsors.json
@@ -46,24 +46,6 @@
             "totalDonations": 950000,
             "source": "opencollective",
             "tier": "silver-sponsor"
-        },
-        {
-            "name": "ESLint",
-            "url": "https://eslint.org/",
-            "image": "https://images.opencollective.com/eslint/96b09dc/logo.png",
-            "monthlyDonation": 10000,
-            "totalDonations": 10000,
-            "source": "opencollective",
-            "tier": "silver-sponsor"
-        },
-        {
-            "name": "ESLint",
-            "url": "https://eslint.org/",
-            "image": "https://images.opencollective.com/eslint/96b09dc/logo.png",
-            "monthlyDonation": 10000,
-            "totalDonations": 10000,
-            "source": "opencollective",
-            "tier": "silver-sponsor"
         }
     ],
     "bronze": [
@@ -284,15 +266,6 @@
             "totalDonations": 350000,
             "source": "opencollective",
             "tier": null
-        },
-        {
-            "name": "ESLint",
-            "url": "https://eslint.org/",
-            "image": "https://images.opencollective.com/eslint/96b09dc/logo.png",
-            "monthlyDonation": 10000,
-            "totalDonations": 40000,
-            "source": "opencollective",
-            "tier": "supporter"
         },
         {
             "name": "Yannick Croissant",

--- a/_tools/fetch-sponsors.js
+++ b/_tools/fetch-sponsors.js
@@ -78,7 +78,7 @@ async function fetchOpenCollectiveSponsors() {
 
     const query = `{
         account(slug: "eslint") {
-          orders(status: ACTIVE) {
+          orders(status: ACTIVE, filter: INCOMING) {
             totalCount
             nodes {
               fromAccount {


### PR DESCRIPTION
This PR fixes a bug with ESLint currently appearing as its own sponsor. This bug is caused by fetching all orders from OC, including those 3 that are actually from ESLint to its dependencies.

After this fix, the `fetch-sponsors.js` script will be fetching only incoming orders.

Since I can't fully test this because I can't run the script due to some GitHub issues, this PR needs help from someone who can.

Remaining steps:

1. Checkout this branch.
2. Set `ESLINT_GITHUB_TOKEN` env variable.
3. Run `node _tools/fetch-sponsors`.
4. Verify diff for `_data/sponsors.json`. The expected outcome is that 3 items with `"name": "ESLint"` should be deleted.
5. Commit and push to this branch if it's okay (I think we're usually fixing `_data/*` in the same PR, not waiting for the bot).