### PR TITLE
Update: add ecmaVersion 2021 and es2021 environment to demo

### DIFF
--- a/src/js/demo/components/App.jsx
+++ b/src/js/demo/components/App.jsx
@@ -61,6 +61,7 @@ const ENV_NAMES = [
     "es6",
     "es2017",
     "es2020",
+    "es2021",
     "greasemonkey"
 ];
 

--- a/src/js/demo/components/ParserOptions.jsx
+++ b/src/js/demo/components/ParserOptions.jsx
@@ -19,6 +19,7 @@ function ParserOptions(props) {
                     <option value="9">2018</option>
                     <option value="10">2019</option>
                     <option value="11">2020</option>
+                    <option value="12">2021</option>
                 </select>
             </div>
             <div className="col-md-4">


### PR DESCRIPTION
This PR adds `2021` to the ECMAVersion list and `es2021` to the list of environments in ESLint's online demo.

Created as a draft since it needs ESLint `v7.8.0`.