### PR TITLE
Update: Add rel=sponsored to sponsor links

### DIFF
--- a/_pages/index.liquid
+++ b/_pages/index.liquid
@@ -46,7 +46,7 @@ homepage: true
               <h4 class="sponsor-heading text-center">{{ tier | capitalize }} Sponsors</h4>
               <div class="sponsor-tier text-center">
                   {% for sponsor in sponsors[tier] %}
-                    <a class="sponsor-link" href="{{ sponsor.url }}" title="{{ sponsor.name }}" rel="noopener nofollow" target="_blank">
+                    <a class="sponsor-link" href="{{ sponsor.url }}" title="{{ sponsor.name }}" rel="noopener nofollow sponsored" target="_blank">
                       <div class="sponsor {{ tier }}-sponsor">
                         <img class="lazyload" data-src="{{ sponsor.image }}" alt="{{ sponsor.name }}">
                       </div>
@@ -58,7 +58,7 @@ homepage: true
       <h4 class="sponsor-heading text-center">Technology Sponsors</h4>
       <div class="sponsor-tier text-center">
         {% for sponsor in techsponsors %}
-        <a class="sponsor-link" href="{{ sponsor.url }}" title="{{ sponsor.name }}" rel="noopener nofollow" target="_blank">
+        <a class="sponsor-link" href="{{ sponsor.url }}" title="{{ sponsor.name }}" rel="noopener nofollow sponsored" target="_blank">
             <div class="sponsor silver-sponsor">
             <img class="lazyload" data-src="{{ sponsor.image }}"
                 alt="{{ sponsor.donation | capitalize }} provided by {{ sponsor.name }}"


### PR DESCRIPTION
This should help further qualify these links to search engines and perhaps further discourage SEO-focused "sponsorships". I found documentation that [Google](https://support.google.com/webmasters/answer/96569?hl=en) and [Bing](https://www.bing.com/webmaster/help/webmaster-guidelines-30fba23a) both support the value and treat it like `nofollow`, but I left `nofollow` as a fallback for any others that might not.

