### PR TITLE
Fix: reset unique header IDs per page (fixes #772)

### DIFF
--- a/_11ty/plugins/markdown-plugins.js
+++ b/_11ty/plugins/markdown-plugins.js
@@ -2,11 +2,10 @@
 
 const markdownIt = require("markdown-it");
 const highlightJS = require("highlight.js");
-const GitHubSlugger = require("github-slugger");
+const { slug } = require("github-slugger");
 
 module.exports = function syntaxHighlighting(eleventyConfig) {
 
-    const slugger = new GitHubSlugger();
     let md = markdownIt({
 
         // https://github.com/markdown-it/markdown-it#syntax-highlighting
@@ -31,7 +30,7 @@ module.exports = function syntaxHighlighting(eleventyConfig) {
         slugify(text) {
 
             // need to replace all the characters GitHub replaces
-            return slugger.slug(text.replace(/[<>()[\]{}]/gu, ""))
+            return slug(text.replace(/[<>()[\]{}]/gu, ""))
 
                 // non-ASCII characters are a pain to fix
                 // first replace them all with dashes


### PR DESCRIPTION
fixes #772

This PR changes the way we use `github-slugger` -> to NOT generate unique slugs.

It uses a documented API (see the end of [github-slugger#usage](https://github.com/Flet/github-slugger#usage) docs):

> If you need, you can also use the underlying implementation which does not keep track of the previously slugged strings (not recommended)

We didn't want to use this API because we wanted to avoid having duplicate IDs on the same page.

However, it turns out that `markdown-it-anchor` already avoids duplicate IDs on the same page [here](https://github.com/valeriangalliat/markdown-it-anchor/blob/de9e3a6cf18b24ab0b59bf787de78196b0135cef/index.js#L36), so it should be safe to not use the unique slug feature of `github-slugger`, which, since it can't be aware of the context, used to generate (unnecessary) unique IDs across the whole site.

Now we don't have unnecessary `-1`, `-2`... suffixes where the ID is already unique on that page:

* https://deploy-preview-782--eslint.netlify.app/docs/rules/comma-dangle#options
* https://deploy-preview-782--eslint.netlify.app/docs/rules/indent#options
* https://deploy-preview-782--eslint.netlify.app/docs/rules/no-unused-vars#options

But we have them where needed:

* https://deploy-preview-782--eslint.netlify.app/docs/developer-guide/scope-manager-interface#deprecated-members
* https://deploy-preview-782--eslint.netlify.app/docs/developer-guide/scope-manager-interface#deprecated-members-2
* https://deploy-preview-782--eslint.netlify.app/docs/developer-guide/scope-manager-interface#deprecated-members-3

Unfortunately, `markdown-it-anchor` starts from `-2`, unlike GitHub which starts from `-1`. I guess we can try to fix that later. Related issue: https://github.com/valeriangalliat/markdown-it-anchor/issues/74