### PR TITLE
Fix: set unique slug start index to 1

### DIFF
--- a/_11ty/plugins/markdown-plugins.js
+++ b/_11ty/plugins/markdown-plugins.js
@@ -38,7 +38,8 @@ module.exports = function syntaxHighlighting(eleventyConfig) {
 
                 // then replace all -- with -
                 .replace(/-+/gu, "-");
-        }
+        },
+        uniqueSlugStartIndex: 1
     });
 
     eleventyConfig.setLibrary("md", md);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2702,7 +2702,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2739,7 +2739,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -3537,7 +3537,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -3550,7 +3550,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -3886,7 +3886,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -7510,9 +7510,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
-      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-6.0.0.tgz",
+      "integrity": "sha512-WOcIGhG1M1W94VV5cmSZAMSKi2vqCxpLAqQZ0wSO9RzQ9Rbls7ecjRVXp5DIPoXrNy9bjv9K7M0nYqNk60ctxQ==",
       "dev": true
     },
     "maximatch": {
@@ -9936,7 +9936,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "less-loader": "^6.1.0",
     "less-plugin-clean-css": "^1.5.1",
     "luxon": "^1.24.1",
-    "markdown-it-anchor": "^5.3.0",
+    "markdown-it-anchor": "^6.0.0",
     "morgan": "^1.10.0",
     "node-fetch": "^2.6.1",
     "regenerator-runtime": "^0.13.5",


### PR DESCRIPTION
This PR changes header ID suffixes (which make IDs being unique on the page) to start from `-1` instead of `-2`.

This will align header IDs on `eslint.org`:

* https://deploy-preview-805--eslint.netlify.app/docs/developer-guide/scope-manager-interface#deprecated-members
* https://deploy-preview-805--eslint.netlify.app/docs/developer-guide/scope-manager-interface#deprecated-members-1
* https://deploy-preview-805--eslint.netlify.app/docs/developer-guide/scope-manager-interface#deprecated-members-2

with header IDs on GitHub:

* https://github.com/eslint/eslint/blob/master/docs/developer-guide/scope-manager-interface.md#deprecated-members
* https://github.com/eslint/eslint/blob/master/docs/developer-guide/scope-manager-interface.md#deprecated-members-1
* https://github.com/eslint/eslint/blob/master/docs/developer-guide/scope-manager-interface.md#deprecated-members-2

These are the same headers on the actual `eslint.org` before this change:

* https://eslint.org/docs/developer-guide/scope-manager-interface#deprecated-members
* https://eslint.org/docs/developer-guide/scope-manager-interface#deprecated-members-2
* https://eslint.org/docs/developer-guide/scope-manager-interface#deprecated-members-3

This change required upgrading `markdown-it-anchor` to `6.0.0`, ref https://github.com/valeriangalliat/markdown-it-anchor/issues/74

