### PR TITLE
Fix: Update Bugsnag URL for Website

### DIFF
--- a/_data/sponsors.json
+++ b/_data/sponsors.json
@@ -115,7 +115,7 @@
         },
         {
             "name": "Bugsnag Stability Monitoring",
-            "url": null,
+            "url": "https://www.bugsnag.com/",
             "image": "https://images.opencollective.com/bugsnag-stability-monitoring/c2cef36/logo.png",
             "monthlyDonation": 20000,
             "totalDonations": 240000,


### PR DESCRIPTION
There was no URL linked for bugsnag. This change adds in the correct URL instead of null.