### PR TITLE
Docs: add noreferrer to rel

### DIFF
--- a/_pages/users.liquid
+++ b/_pages/users.liquid
@@ -10,7 +10,7 @@ ad: text
     {% for logo in logos %}
         <div>
             <div class="slide col-sm-4">
-                <a href="{{ logo.url }}" rel="noopener nofollow" target="_blank">
+                <a href="{{ logo.url }}" rel="noopener noreferrer nofollow" target="_blank">
                     <img src="{{ logo.src }}" alt="{{ logo.name }}" lazyload>
                 </a>
             </div>


### PR DESCRIPTION
I believe it's very common to use `noreferrer` alongside `noopener` https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer.