### PR TITLE
Fix: Check for User and Organization sponsors (fixes #829)

### DIFF
--- a/_tools/fetch-sponsors.js
+++ b/_tools/fetch-sponsors.js
@@ -134,10 +134,17 @@ async function fetchGitHubSponsors() {
               sponsor: sponsorEntity {
                 ...on User {
                   name,
-                 login,
-                 avatarUrl,
-                 url,
-                 websiteUrl
+                  login,
+                  avatarUrl,
+                  url,
+                  websiteUrl
+                }
+                ...on Organization {
+                  name,
+                  login,
+                  avatarUrl,
+                  url,
+                  websiteUrl
                 }
               },
               tier {


### PR DESCRIPTION
It turns out that because Substack is an organization instead of a user, we weren't pulling that data at all. This fixes our script to pull organization data, too.