### PR TITLE
Fix: update slugify function

### DIFF
--- a/_11ty/plugins/markdown-plugins.js
+++ b/_11ty/plugins/markdown-plugins.js
@@ -32,8 +32,7 @@ module.exports = function syntaxHighlighting(eleventyConfig) {
             // need to replace all the characters GitHub replaces
             return slug(text.replace(/[<>()[\]{}]/gu, ""))
 
-                // non-ASCII characters are a pain to fix
-                // remove them
+                // remove non-ASCII characters
                 .replace(/[^\u{00}-\u{FF}]/gu, "");
         },
         uniqueSlugStartIndex: 1

--- a/_11ty/plugins/markdown-plugins.js
+++ b/_11ty/plugins/markdown-plugins.js
@@ -33,11 +33,8 @@ module.exports = function syntaxHighlighting(eleventyConfig) {
             return slug(text.replace(/[<>()[\]{}]/gu, ""))
 
                 // non-ASCII characters are a pain to fix
-                // first replace them all with dashes
-                .replace(/[^\u{00}-\u{FF}]/gu, "-")
-
-                // then replace all -- with -
-                .replace(/-+/gu, "-");
+                // remove them
+                .replace(/[^\u{00}-\u{FF}]/gu, "");
         },
         uniqueSlugStartIndex: 1
     });


### PR DESCRIPTION
As discussed in https://github.com/eslint/eslint/pull/14743 with @mdjermanovic.

But that issue is sort of messy now, so I'll explain in details for why updating the `slugify` function here.

## Problems

The current implementation would replace `--` in headers' ids with `-`, which means with header text like `--resolve-plugins-relative-to` we will have header id [`-resolve-plugins-relative-to`](https://eslint.org/docs/user-guide/command-line-interface#-resolve-plugins-relative-to) on website.

Generally it's not a big deal as long as we use the id of the single `-` version when linking to those headers. E.g.,

```md
[some text](#-resolve-plugins-relative-to)
```
But it will become a problem if we're going to browser the documentation on Github because Github would generate double `-` for the aforementioned header text and that process is not customizable. This discrepancy would be a pain for users either on website or on Github because one of the two versions will have a broken link.

## Solution

We just stop replacing `--` with `-` to keep consistency between the website and github.

## Side effects

As the `slugify` function was introduced 11 months ago, we would expect some links to break inevitably.

But it's tolerable as we assessed here:

1. https://github.com/eslint/eslint/pull/14743#issuecomment-868900249
2. https://github.com/eslint/eslint/pull/14743#issuecomment-869021349

And some of them are fixable once this pull request gets merged. See todo later.

## TODO

- [ ] fix those links with `#-` instead of `#--` as they could be broken once `slugify` gets updated.
- [ ] remove the superfluous whitespace mentioned in https://github.com/eslint/eslint/pull/14743#issuecomment-869089153 so its id can stay the same as before.