### PR TITLE
Docs: Use emojis instead of images to indicate fixable/recommended rules

### DIFF
--- a/_layouts/doc.liquid
+++ b/_layouts/doc.liquid
@@ -28,8 +28,8 @@
         | replace: '<p>(recommended) ', '<p class="recommended icon">'
         | replace: '<p>(removed) ', '<p class="removed icon">'
         | replace: '<p>(fixable) ', '<p class="fixable icon">'
-        | replace: '(recommended)', '<span title="recommended" aria-label="recommended" class="glyphicon glyphicon-ok"></span>'
-        | replace: '(fixable)', '<span title="fixable" aria-label="fixable" class="glyphicon glyphicon-wrench"></span>'
+        | replace: '(recommended)', '<span title="recommended" aria-label="recommended">✓</span>'
+        | replace: '(fixable)', '<span title="fixable" aria-label="fixable">🔧</span>'
       }}
     </article>
   </main>

--- a/_layouts/rules.liquid
+++ b/_layouts/rules.liquid
@@ -14,8 +14,8 @@
       </div>
 
       {{ content
-        | replace: '(recommended)', '<span title="recommended" aria-label="recommended" class="glyphicon glyphicon-ok"></span>'
-        | replace: '(fixable)', '<span title="fixable" aria-label="fixable" class="glyphicon glyphicon-wrench"></span>'
+        | replace: '(recommended)', '<span title="recommended" aria-label="recommended">✓</span>'
+        | replace: '(fixable)', '<span title="fixable" aria-label="fixable">🔧</span>'
       }}
     </article>
   </main>

--- a/src/styles/lib/overrides.less
+++ b/src/styles/lib/overrides.less
@@ -89,7 +89,7 @@ p {
   }
 
   &.recommended:before {
-    content: "\e013"; /* ok */
+    content: "✓"; /* ok */
   }
 
   &.removed:before {
@@ -97,7 +97,7 @@ p {
   }
 
   &.fixable:before {
-    content: "\e136"; /* wrench */
+    content: "🔧"; /* wrench */
   }
 
   &.incorrect:before {


### PR DESCRIPTION
In the rule page, I wanted to search for all auto-fixable rules but the icon was an image instead of unicode, so I couldn't do a ctrl-f. So this PR changes chechmarks and wrenches to unicode to allow searching, which should make it easier for people to find the rules they're looking for.

Screenshot of how it looks below. Chechmarks could be ✅ or some other things instead if people prefer it.

before | after
--- | ---
<img width="1275" alt="before" src="https://user-images.githubusercontent.com/10591373/125666337-0279da20-4e20-4350-ae61-490e90c3da87.png"> | <img width="904" alt="after" src="https://user-images.githubusercontent.com/10591373/125312530-5c206a00-e302-11eb-9bf5-dc768fa3fa29.png">
