### PR TITLE
Chore: Update CI build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/eslint/website.svg?branch=master)](https://travis-ci.org/eslint/website)
+[![Build Status](https://github.com/eslint/website/actions/workflows/ci.yml/badge.svg)](https://github.com/eslint/website/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/cefb59aa-729a-4f8e-be36-b981fda399c0/deploy-status)](https://app.netlify.com/sites/eslint/deploys)
 
 # ESLint Web Site


### PR DESCRIPTION
Switched the badge to show the GitHub actions CI status, as it does not look like Travis is actively used anymore.