### PR TITLE
Docs: fix fixable example

### DIFF
--- a/docs/8.0.0/user-guide/migrating-to-8.0.0.md
+++ b/docs/8.0.0/user-guide/migrating-to-8.0.0.md
@@ -150,7 +150,7 @@ module.exports = function(context) {
 Then rewrite your rule in this format:
 
 ```js
-module.exports = function(context) {
+module.exports = {
     meta: {
         fixable: "code" // or "whitespace"
     },


### PR DESCRIPTION
The example should be:

```js
module.exports = {
    meta: {
        fixable: "code" // or "whitespace"
    },
    create(context) {
        // your rule
    }
};
```

instead of


```js
module.exports = function(context) {
    meta: {
        fixable: "code" // or "whitespace"
    },
    create(context) {
        // your rule
    }
};
```


