### PR TITLE
Fix: OC `frequency` enum value is `YEARLY`

### DIFF
--- a/_tools/fetch-sponsors.js
+++ b/_tools/fetch-sponsors.js
@@ -113,7 +113,7 @@ async function fetchOpenCollectiveSponsors() {
         name: order.fromAccount.name,
         url: order.fromAccount.website,
         image: order.fromAccount.imageUrl,
-        monthlyDonation: order.frequency === "year" ? Math.round(order.amount.value * 100 / 12) : order.amount.value * 100,
+        monthlyDonation: order.frequency === "YEARLY" ? Math.round(order.amount.value * 100 / 12) : order.amount.value * 100,
         totalDonations: order.totalDonations.value * 100,
         source: "opencollective",
         tier: order.tier ? order.tier.slug : null


### PR DESCRIPTION
See https://graphql-docs-v2.opencollective.com/contributionfrequency.doc.html

Thanks for this great script! I've adapted it for Cheerio: https://github.com/cheeriojs/cheerio/blob/2cb6812d45dd3a97b7fd9c17c82d4c5d0055b3f0/scripts/fetch-sponsors.ts