### PR TITLE
Chore: use `actions/setup-node@v2` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: '12.x'
       - name: Install dependencies


### PR DESCRIPTION
CI-related change.

updated `setup-node` action to `v2` for CI node workflow.

https://github.com/marketplace/actions/setup-node-js-environment