### PR TITLE
Update: add ecmaVersion 2022 to ESLint demo

### DIFF
--- a/src/js/demo/components/App.jsx
+++ b/src/js/demo/components/App.jsx
@@ -76,7 +76,7 @@ export default class App extends Component {
             urlState || storedState || {
                 options: {
                     parserOptions: {
-                        ecmaVersion: 12,
+                        ecmaVersion: 13,
                         sourceType: "script",
                         ecmaFeatures: {}
                     },

--- a/src/js/demo/components/ParserOptions.jsx
+++ b/src/js/demo/components/ParserOptions.jsx
@@ -20,6 +20,7 @@ function ParserOptions(props) {
                     <option value="10">2019</option>
                     <option value="11">2020</option>
                     <option value="12">2021</option>
+                    <option value="13">2022</option>
                 </select>
             </div>
             <div className="col-md-4">


### PR DESCRIPTION
This PR adds `2022` to the ECMA Version list in ESLint demo, and sets it as default.