### PR TITLE
docs: Update blog post layout

### DIFF
--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -34,6 +34,9 @@
             <br />
             {% endif %}
             <br />
+            {% if teaser %}
+            <p>{{ teaser }}</p>
+            {% endif %}
             {{ content }}
             <footer>
               <p class="text-center">ESLint depends on the support of individuals and companies. <a class="btn btn-default" href="https://opencollective.com/eslint">Become a Sponsor</a></p>


### PR DESCRIPTION
Inserts the blog post teaser directly into the body content of the post. In the new design, the teaser will be visually separated from the body content, but for right now, it's just the first paragraph. This is to help us prepare for the new site design.

Related to: https://github.com/eslint/eslint/pull/15285