### PR TITLE
feat: explicitly specify if a rule is deprecated

### DIFF
--- a/src/js/demo/components/Rule.jsx
+++ b/src/js/demo/components/Rule.jsx
@@ -14,7 +14,7 @@ function Rule(props) {
                 title={props.rule}
             >
                 <input type="checkbox" checked={props.isChecked} id={props.rule} onChange={handler} />
-                {props.rule}
+                {props.rule} {props.isDeprecated ? "(deprecated)" : ""}
             </label>
         </div>
     );

--- a/src/js/demo/components/RulesConfig.jsx
+++ b/src/js/demo/components/RulesConfig.jsx
@@ -48,6 +48,7 @@ export default class RulesConfig extends PureComponent {
                     key={rule}
                     rule={rule}
                     docs={this.props.docs[rule].docs}
+                    isDeprecated={this.props.docs[rule].deprecated}
                     isChecked={this.shouldBeChecked(rule)}
                     onChange={this.handleSingleChange}
                 />;


### PR DESCRIPTION
Refers https://github.com/eslint/website/issues/878

Show `deprecated` tag if a rule is deprecated.

## Screenshot

<img width="280" alt="Screenshot 2021-12-06 at 9 16 12 AM" src="https://user-images.githubusercontent.com/46647141/144784142-5f606ea2-6844-4fbc-aeab-798159c1a483.png">
