### PR TITLE
docs: fix wrong version in v8.0.1 teaser

### DIFF
--- a/_posts/2021-10-13-eslint-v8.0.1-released.md
+++ b/_posts/2021-10-13-eslint-v8.0.1-released.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ESLint v8.0.1 released
-teaser: "We just pushed ESLint v8.4.1, which is a patch release upgrade of ESLint. This release fixes several bugs found in the previous release."
+teaser: "We just pushed ESLint v8.0.1, which is a patch release upgrade of ESLint. This release fixes several bugs found in the previous release."
 image: release-notes-patch.png
 tags:
   - release


### PR DESCRIPTION
Teaser of the blog-post announcing ESLint v8.0.1 accidentally says v8.4.1 instead of v8.0.1
