### PR TITLE
chore: Add teaser property to remaining blog posts

### DIFF
--- a/_posts/2014-11-15-es6-jsx-support.md
+++ b/_posts/2014-11-15-es6-jsx-support.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Announcing ES6 and JSX Support
+teaser: "We are starting work on integrating ES6 and JSX. A prerelease version is available for testing. We also share how you can further contribute and what we are planning for the release."
 tags:
   - ES6
   - JSX

--- a/_posts/2014-12-24-espree-esprima.md
+++ b/_posts/2014-12-24-espree-esprima.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Introducing Espree, an Esprima alternative
+teaser: "As part of integrating ES6 and JSX, we have released our own parser, Espree, based on Esprima. Feature flags have been introduced to configure language options while maintaining backwards compatibility. We also share how you can help and what we are planning for future releases."
 tags:
   - ES6
   - JSX

--- a/_posts/2016-04-19-eslint-joins-the-jquery-foundation.md
+++ b/_posts/2016-04-19-eslint-joins-the-jquery-foundation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ESLint Joins The jQuery Foundation
-teaser: "We are happy to announce that ESLint is now part of the jQuery Foundation. This is a huge step and we share what this means for the project. We're also looking forward to its growth throughout the open-source community."
+teaser: "We are happy to announce that ESLint is now part of the jQuery Foundation. This is a huge step and we share what this means for the project. We're also looking forward to its growth throughout the open source community."
 date: 2016-04-19
 tags:
   - jQuery Foundation

--- a/_posts/2016-04-19-eslint-joins-the-jquery-foundation.md
+++ b/_posts/2016-04-19-eslint-joins-the-jquery-foundation.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: ESLint Joins The jQuery Foundation
+teaser: "We are happy to announce that ESLint is now part of the jQuery Foundation. This is a huge step and we share what this means for the project. We're also looking forward to its growth throughout the open-source community."
 date: 2016-04-19
 tags:
   - jQuery Foundation

--- a/_posts/2016-07-01-eslint-new-rule-format.md
+++ b/_posts/2016-07-01-eslint-new-rule-format.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: ESLint's New Rule Format
+teaser: "As part of automating the process of generating rules documentation, ESLint rules now have a new format. We explain the elements of this new format and how you can automatically transform rules from the old format to the new one. If you're a plugin author, it is recommended to update your custom rules accordingly."
 tags:
   - rules
   - development

--- a/_posts/2016-07-15-jscs-end-of-life.md
+++ b/_posts/2016-07-15-jscs-end-of-life.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: JSCS End of Life
+teaser: "JSCS has reached its end of life and its developers will now work on ESLint. We share what this means for JSCS and how we plan to facilitate the switch from JSCS to ESLint. Meanwhile, we recommend to wait for most compatibility work to be complete before switching."
 tags:
   - jscs
   - end of life

--- a/_posts/2018-07-12-postmortem-for-malicious-package-publishes.md
+++ b/_posts/2018-07-12-postmortem-for-malicious-package-publishes.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Postmortem for Malicious Packages Published on July 12th, 2018
+teaser: "Malicious versions of some ESLint packages were published (now unpublished) and we are sorry about this. We share details of the attack and our precautionary recommendations for package maintainers. Please, check that you are not using the affected packages."
 tags:
   - security
 authors:

--- a/_posts/2018-07-12-postmortem-for-malicious-package-publishes.md
+++ b/_posts/2018-07-12-postmortem-for-malicious-package-publishes.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Postmortem for Malicious Packages Published on July 12th, 2018
-teaser: "Malicious versions of some ESLint packages were published (now unpublished) and we are sorry about this. We share details of the attack and our precautionary recommendations for package maintainers. Please, check that you are not using the affected packages."
+teaser: "Malicious versions of some ESLint packages were published (now unpublished) and we are sorry about this. We share details of the attack and our precautionary recommendations for package maintainers. Please check that you are not using the affected packages."
 tags:
   - security
 authors:

--- a/_posts/2019-01-18-future-typescript-eslint.md
+++ b/_posts/2019-01-18-future-typescript-eslint.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: The future of TypeScript on ESLint
+teaser: "We are excited that the TypeScript team has decided to officially work on improving the TypeScript ESLint experience. The driving force behind TypeScript compatibility for ESLint, James Henry, will work with the TypeScript team on this new project. We share what this means for the ESLint team and for TypeScript users."
 tags:
   - typescript
   - parser

--- a/_posts/2019-02-12-funding-eslint-future.md
+++ b/_posts/2019-02-12-funding-eslint-future.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Funding ESLint's Future
+teaser: "With ESLint being an important part of the JS ecosystem, we are happy to announce the launch of the ESLint Collective. We share what this means and our goals and plans, and we introduce our first sponsors. Thanks to the ESLint community, we can make ESLint's development more sustainable."
 tags:
   - Open Source
   - Funding

--- a/_posts/2019-05-01-funding-update.md
+++ b/_posts/2019-05-01-funding-update.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: 'Funding ESLint''s Future: An Update'
+teaser: "We are happy to announce that we are currently sponsored at over $7,000 per month. In the last quarter, since the launch of the ESLint Collective, numerous sponsors have reached out. We are humbled that so many have contributed to raise funds to help support the team developing ESLint."
 tags:
   - Open Source
   - Funding

--- a/_posts/2019-09-09-indeed-donates-10000-to-eslint.md
+++ b/_posts/2019-09-09-indeed-donates-10000-to-eslint.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Indeed donates $10,000 to ESLint
+teaser: "We are happy to announce that Indeed has donated $10,000 to ESLint, as part of their FOSS Contributor Fund. It is an honor to be supported by Indeed. We are grateful to the head of Open Source, Duane O'Brien, and the employees who contributed to and nominated ESLint."
 tags:
   - Open Source
   - Funding

--- a/_posts/2019-11-07-funding-update.md
+++ b/_posts/2019-11-07-funding-update.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: 'Funding ESLint''s Future: November Update'
+teaser: "We are happy to announce that we are currently sponsored at just under $10,000 per month. We share how we've used the money and what our sponsors are telling us. Thanks to the ESLint Collective, we are looking forward to a brighter future for ESLint."
 tags:
   - Open Source
   - Funding

--- a/_posts/2020-08-06-salesforce-donates-10000-to-eslint.md
+++ b/_posts/2020-08-06-salesforce-donates-10000-to-eslint.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Salesforce donates $10,000 to ESLint
+teaser: "We are happy to announce that Salesforce has donated $10,000 to ESLint, as part of their FOSS Contributor Fund. It is an honor to be supported by Salesforce. We are grateful to the technical architect, Médédé Raymond Kpatchaa, for nominating ESLint, and the employees who voted for us."
 tags:
   - Open Source
   - Funding

--- a/_posts/2020-08-10-making-eslint-more-inclusive.md
+++ b/_posts/2020-08-10-making-eslint-more-inclusive.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Making ESLint more inclusive
+teaser: "As part of our efforts to make ESLint more inclusive, we are happy to share with you changes we've made in the project. ESLint is maintained by a diverse team, and we want everyone to feel empowered, welcome, safe, proud, and included, when contributing. Moving forward, we are looking to do even more, and we hope to inspire other open source projects."
 tags:
   - Inclusivity
   - Diversity

--- a/_posts/2020-08-13-microsoft-donates-10000-to-eslint.md
+++ b/_posts/2020-08-13-microsoft-donates-10000-to-eslint.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Microsoft donates $10,000 to ESLint as first FOSS Fund recipient
+teaser: "We are happy to announce that Microsoft has donated $10,000 to ESLint, as part of their FOSS Contributor Fund. It is an honor to be supported by Microsoft and to be their first recipient. We are grateful to the software engineers, Jan Pilzer and Steve Faulkner, for nominating ESLint, and the employees who voted for us."
 tags:
   - Open Source
   - Funding

--- a/_posts/2020-08-19-eslint-google-season-of-docs-project-writer.md
+++ b/_posts/2020-08-19-eslint-google-season-of-docs-project-writer.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Introducing the ESLint Google Season of Docs project and technical writer
+teaser: "We are happy to announce that ESLint was accepted into the Google Season of Docs program. It is with pleasure that we introduce our technical writer for 2020, Khawar Latif Khan. We are looking forward to working with him on his proposed project for our configuration documentation."
 tags:
   - Google Season of Docs
   - Technical Writing

--- a/_posts/2020-08-28-eslint-public-roadmap.md
+++ b/_posts/2020-08-28-eslint-public-roadmap.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Announcing ESLint's public roadmap
+teaser: "We are happy to announce the first public roadmap of ESLint. Thanks to donations and involved contributors, we have been able to plan development time and future expectations. We hope that this will help to give a better idea of our ongoing resource allocation and how your donations contribute to the project."
 tags:
   - Sponsorships
   - Donations

--- a/_posts/2020-09-16-supporting-eslint-dependencies.md
+++ b/_posts/2020-09-16-supporting-eslint-dependencies.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Supporting ESLint's dependencies
+teaser: "As part of our goal for open source sustainability, we are happy to announce that we're starting to support ESLint's dependencies. We're grateful to the projects upon which ESLint is built and we want to share our success with them. Thanks to our sponsors, we're able to help them, and we hope to extend this to more dependencies."
 tags:
   - Sponsorships
   - Donations

--- a/_posts/2020-10-07-year-paying-contributors-review.md
+++ b/_posts/2020-10-07-year-paying-contributors-review.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: 'A year of paying contributors: Review'
+teaser: "As part of the goals of the ESLint Collective, we have been paying contributors over the past year. We share the different approaches we tried and their results. We value the time of our contributors and we are continuously finding better ways to reward their work."
 tags:
   - Sponsorships
   - Donations

--- a/_posts/2020-12-10-automattic-platinum-sponsor-eslint.md
+++ b/_posts/2020-12-10-automattic-platinum-sponsor-eslint.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Automattic becomes ESLint's first platinum sponsor
+teaser: "We are happy to announce that Automattic is the first platinum sponsor of ESLint. It is an honor to be supported by Automattic. We are grateful to the engineers using ESLint, and specially to Sarah Gooding of WPTavern for covering ESLint in her article about funding open source projects."
 tags:
   - Open Source
   - Funding

--- a/_posts/2021-01-13-chrome-gold-sponsor-eslint.md
+++ b/_posts/2021-01-13-chrome-gold-sponsor-eslint.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Google Chrome becomes ESLint gold sponsor
+teaser: "We are happy to announce that Google Chrome is a gold sponsor of ESLint. It is an honor to be supported by Google Chrome. We are grateful to Addy Osmani, Senior Staff Engineering Manager, for recommending us for the sponsorship, and to the Chrome team."
 tags:
   - Open Source
   - Funding

--- a/_posts/2021-02-18-nx-gold-sponsor-eslint.md
+++ b/_posts/2021-02-18-nx-gold-sponsor-eslint.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Nx becomes ESLint gold sponsor
+teaser: "We are happy to announce that Nx is a gold sponsor of ESLint. It is an honor to be supported by Nx. We are grateful to Jeff Cross, Co-founder and Principal Architect, and Victor Savkin, Co-founder, and to the Nx team."
 tags:
   - Open Source
   - Funding

--- a/_posts/2021-12-01-contra-gold-sponsor-eslint.md
+++ b/_posts/2021-12-01-contra-gold-sponsor-eslint.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Contra becomes ESLint gold sponsor
-teaser: "We are happy to announce that Contra is a gold sponsor of ESLint. It is an honor to be supported by Contra. We are grateful to Gajus Kuizinas, Co-Founder / CTO, and to the Contra team."
+teaser: "We are happy to announce that Contra is a gold sponsor of ESLint. It is an honor to be supported by Contra. We are grateful to Gajus Kuizinas, Co-Founder/CTO, and to the Contra team."
 authors:
   - nzakas
 categories:

--- a/_posts/2021-12-01-contra-gold-sponsor-eslint.md
+++ b/_posts/2021-12-01-contra-gold-sponsor-eslint.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Contra becomes ESLint gold sponsor
+teaser: "We are happy to announce that Contra is a gold sponsor of ESLint. It is an honor to be supported by Contra. We are grateful to Gajus Kuizinas, Co-Founder / CTO, and to the Contra team."
 authors:
   - nzakas
 categories:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "anchor-js": "^4.2.2",
         "bootstrap": "^3.4.1",
         "bootstrap.native": "^2.0.27",
-        "codemirror": "^5.54.0",
+        "codemirror": "^5.58.2",
         "docsearch.js": "^2.6.3",
         "highlight.js": "^10.4.1",
         "react": "^16.13.1",
@@ -3471,9 +3471,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.54.0.tgz",
-      "integrity": "sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q=="
+      "version": "5.65.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.1.tgz",
+      "integrity": "sha512-s6aac+DD+4O2u1aBmdxhB7yz2XU7tG3snOyQ05Kxifahz7hoxnfxIRHxiCSEv3TUC38dIVH8G+lZH9UWSfGQxA=="
     },
     "node_modules/collection-visit": {
       "version": "1.0.0",
@@ -16943,9 +16943,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.58.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.2.tgz",
-      "integrity": "sha512-K/hOh24cCwRutd1Mk3uLtjWzNISOkm4fvXiMO7LucCrqbh6aJDdtqUziim3MZUI6wOY0rvY1SlL1Ork01uMy6w=="
+      "version": "5.65.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.1.tgz",
+      "integrity": "sha512-s6aac+DD+4O2u1aBmdxhB7yz2XU7tG3snOyQ05Kxifahz7hoxnfxIRHxiCSEv3TUC38dIVH8G+lZH9UWSfGQxA=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -21520,6 +21520,12 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -22331,28 +22337,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.2.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
-      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.6.tgz",
+      "integrity": "sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==",
       "dev": true,
       "requires": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
+        "colorette": "^1.2.1",
+        "nanoid": "^3.1.20",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "colorette": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-          "dev": true
-        },
-        "nanoid": {
-          "version": "3.1.23",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-          "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
-          "dev": true
-        }
       }
     },
     "postcss-modules-extract-imports": {


### PR DESCRIPTION
Hello!

I added the `teaser` property to remaining blog posts.

Fixes #903

Posts:

- `_posts/2021-12-01-contra-gold-sponsor-eslint.md`
- `_posts/2021-02-18-nx-gold-sponsor-eslint.md`
- `_posts/2021-01-13-chrome-gold-sponsor-eslint.md`
- `_posts/2020-12-10-automattic-platinum-sponsor-eslint.md`
- `_posts/2020-10-07-year-paying-contributors-review.md`
- `_posts/2020-09-16-supporting-eslint-dependencies.md`
- `_posts/2020-08-28-eslint-public-roadmap.md`
- `_posts/2020-08-19-eslint-google-season-of-docs-project-writer.md`
- `_posts/2020-08-10-making-eslint-more-inclusive.md`
- `_posts/2020-08-13-microsoft-donates-10000-to-eslint.md`
- `_posts/2020-08-06-salesforce-donates-10000-to-eslint.md`
- `_posts/2019-11-07-funding-update.md`
- `_posts/2019-09-09-indeed-donates-10000-to-eslint.md`
- `_posts/2019-05-01-funding-update.md`
- `_posts/2019-02-12-funding-eslint-future.md`
- `_posts/2019-01-18-future-typescript-eslint.md`
- `_posts/2018-07-12-postmortem-for-malicious-package-publishes.md`
- `_posts/2016-07-15-jscs-end-of-life.md`
- `_posts/2016-07-01-eslint-new-rule-format.md`
- `_posts/2016-04-19-eslint-joins-the-jquery-foundation.md`
- `_posts/2014-12-24-espree-esprima.md`
- `_posts/2014-11-15-es6-jsx-support.md`