### PR TITLE
fix: Display authors with correct GitHub URL on blog posts

### DIFF
--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -17,7 +17,7 @@
               by <a href="https://github.com/{{ author }}"><b>{{ contributors[author].name }}</b></a><em> - </em>
             {% elsif authors != null %}
               by 
-                {% assign members = authors | split: ", " %}
+                {% assign members = authors | split: "," %}
                   {% for member in members %}
                     {% if forloop.last == true %}
                       <a href="https://github.com/{{ member }}"><b>{{ contributors[member].name }}</b></a>

--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -17,8 +17,7 @@
               by <a href="https://github.com/{{ author }}"><b>{{ contributors[author].name }}</b></a><em> - </em>
             {% elsif authors != null %}
               by 
-                {% assign members = authors | split: "," %}
-                  {% for member in members %}
+                  {% for member in authors %}
                     {% if forloop.last == true %}
                       <a href="https://github.com/{{ member }}"><b>{{ contributors[member].name }}</b></a>
                     {% else %}


### PR DESCRIPTION
On blog posts with more than 1 author, the authors are now displayed, each with their correct GitHub URL.

![image](https://user-images.githubusercontent.com/81232315/151985414-43539e56-e6d4-4035-9488-f0959cf62bd9.png)

When getting the `authors` array, I changed the `split` filter from `", "` to `","`.

Fixes #913