### PR TITLE
fix: Update blog post authors

### DIFF
--- a/_posts/2014-01-19-breaking-change-formatter.md
+++ b/_posts/2014-01-19-breaking-change-formatter.md
@@ -7,7 +7,6 @@ tags:
   - formatter
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - API Changes
 ---

--- a/_posts/2014-01-20-breaking-change-config-file.md
+++ b/_posts/2014-01-20-breaking-change-config-file.md
@@ -7,7 +7,6 @@ tags:
   - config file
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - API Changes
 ---

--- a/_posts/2014-01-20-eslint-0.3.0-released.md
+++ b/_posts/2014-01-20-eslint-0.3.0-released.md
@@ -8,8 +8,6 @@ tags:
   - release
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-02-12-eslint-0.4.0-released.md
+++ b/_posts/2014-02-12-eslint-0.4.0-released.md
@@ -8,7 +8,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-03-03-eslint-0.4.2-released.md
+++ b/_posts/2014-03-03-eslint-0.4.2-released.md
@@ -8,7 +8,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-03-18-eslint-0.4.3-released.md
+++ b/_posts/2014-03-18-eslint-0.4.3-released.md
@@ -8,7 +8,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-03-25-eslint-0.4.4-released.md
+++ b/_posts/2014-03-25-eslint-0.4.4-released.md
@@ -8,7 +8,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-03-29-eslint-0.4.5-released.md
+++ b/_posts/2014-03-29-eslint-0.4.5-released.md
@@ -8,9 +8,6 @@ tags:
   - release
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-04-10-eslint-0.5.0-released.md
+++ b/_posts/2014-04-10-eslint-0.5.0-released.md
@@ -8,9 +8,6 @@ tags:
   - release
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-04-17-eslint-0.5.1-released.md
+++ b/_posts/2014-04-17-eslint-0.5.1-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-05-17-eslint-0.6.0-released.md
+++ b/_posts/2014-05-17-eslint-0.6.0-released.md
@@ -8,9 +8,6 @@ tags:
   - release
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-05-17-eslint-0.6.1-released.md
+++ b/_posts/2014-05-17-eslint-0.6.1-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-05-23-eslint-0.6.2-released.md
+++ b/_posts/2014-05-23-eslint-0.6.2-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-06-21-formatter-breaking-change.md
+++ b/_posts/2014-06-21-formatter-breaking-change.md
@@ -7,7 +7,6 @@ tags:
   - formatter
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - API Changes
 ---

--- a/_posts/2014-07-07-eslint-0.7.1-released.md
+++ b/_posts/2014-07-07-eslint-0.7.1-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-07-08-eslint-0.7.2-released.md
+++ b/_posts/2014-07-08-eslint-0.7.2-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-07-09-eslint-0.7.3-released.md
+++ b/_posts/2014-07-09-eslint-0.7.3-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-07-10-eslint-0.7.4-released.md
+++ b/_posts/2014-07-10-eslint-0.7.4-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-09-05-eslint-0.8.0-released.md
+++ b/_posts/2014-09-05-eslint-0.8.0-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-09-09-eslint-0.8.1-released.md
+++ b/_posts/2014-09-09-eslint-0.8.1-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-09-20-eslint-0.8.2-released.md
+++ b/_posts/2014-09-20-eslint-0.8.2-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-10-24-eslint-0.9.0-released.md
+++ b/_posts/2014-10-24-eslint-0.9.0-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-10-25-eslint-0.9.1-released.md
+++ b/_posts/2014-10-25-eslint-0.9.1-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-11-01-eslint-0.9.2-released.md
+++ b/_posts/2014-11-01-eslint-0.9.2-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-11-15-es6-jsx-support.md
+++ b/_posts/2014-11-15-es6-jsx-support.md
@@ -7,7 +7,6 @@ tags:
   - JSX
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Announcements
 ---

--- a/_posts/2014-11-27-eslint-0.10.0-released.md
+++ b/_posts/2014-11-27-eslint-0.10.0-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-12-06-eslint-0.10.1-released.md
+++ b/_posts/2014-12-06-eslint-0.10.1-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-12-12-eslint-0.10.2-released.md
+++ b/_posts/2014-12-12-eslint-0.10.2-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2014-12-24-espree-esprima.md
+++ b/_posts/2014-12-24-espree-esprima.md
@@ -7,7 +7,6 @@ tags:
   - JSX
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Announcements
 ---

--- a/_posts/2014-12-30-eslint-0.11.0-released.md
+++ b/_posts/2014-12-30-eslint-0.11.0-released.md
@@ -8,7 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-01-17-eslint-0.12.0-released.md
+++ b/_posts/2015-01-17-eslint-0.12.0-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-01-24-eslint-0.13.0-released.md
+++ b/_posts/2015-01-24-eslint-0.13.0-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-02-07-eslint-0.14.0-released.md
+++ b/_posts/2015-02-07-eslint-0.14.0-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - okuryu
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-02-08-eslint-0.14.1-released.md
+++ b/_posts/2015-02-08-eslint-0.14.1-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-02-21-eslint-0.15.0-released.md
+++ b/_posts/2015-02-21-eslint-0.15.0-released.md
@@ -8,10 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - zpao
-  - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-02-26-eslint-0.15.1-released.md
+++ b/_posts/2015-02-26-eslint-0.15.1-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-03-07-eslint-0.16.0-released.md
+++ b/_posts/2015-03-07-eslint-0.16.0-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - cvrebert
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-03-08-eslint-0.16.1-released.md
+++ b/_posts/2015-03-08-eslint-0.16.1-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-03-10-eslint-0.16.2-released.md
+++ b/_posts/2015-03-10-eslint-0.16.2-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-03-14-eslint-0.17.0-released.md
+++ b/_posts/2015-03-14-eslint-0.17.0-released.md
@@ -8,7 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-03-17-eslint-0.17.1-released.md
+++ b/_posts/2015-03-17-eslint-0.17.1-released.md
@@ -8,7 +8,6 @@ tags:
   - bug fix
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-03-28-eslint-0.18.0-released.md
+++ b/_posts/2015-03-28-eslint-0.18.0-released.md
@@ -8,8 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-04-11-eslint-0.19.0-released.md
+++ b/_posts/2015-04-11-eslint-0.19.0-released.md
@@ -8,7 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-04-24-eslint-0.20.0-released.md
+++ b/_posts/2015-04-24-eslint-0.20.0-released.md
@@ -8,7 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-05-09-eslint-0.21.0-released.md
+++ b/_posts/2015-05-09-eslint-0.21.0-released.md
@@ -8,9 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - gcochard
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-05-15-eslint-0.21.1-released.md
+++ b/_posts/2015-05-15-eslint-0.21.1-released.md
@@ -8,7 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-05-18-eslint-0.21.2-released.md
+++ b/_posts/2015-05-18-eslint-0.21.2-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-05-30-eslint-0.22.0-released.md
+++ b/_posts/2015-05-30-eslint-0.22.0-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-05-30-eslint-0.22.1-released.md
+++ b/_posts/2015-05-30-eslint-0.22.1-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-06-14-eslint-0.23.0-released.md
+++ b/_posts/2015-06-14-eslint-0.23.0-released.md
@@ -7,8 +7,6 @@ tags:
   - release
 authors:
   - ilyavolodin
-  - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-06-26-eslint-0.24.0-released.md
+++ b/_posts/2015-06-26-eslint-0.24.0-released.md
@@ -7,8 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
-  - dotJoel
 categories:
   - Release Notes
 ---

--- a/_posts/2015-06-26-preparing-for-1.0.0.md
+++ b/_posts/2015-06-26-preparing-for-1.0.0.md
@@ -7,7 +7,6 @@ tags:
   - announcement
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Announcements
 ---

--- a/_posts/2015-07-10-eslint-0.24.1-released.md
+++ b/_posts/2015-07-10-eslint-0.24.1-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-07-15-eslint-1.0.0-rc-1-released.md
+++ b/_posts/2015-07-15-eslint-1.0.0-rc-1-released.md
@@ -7,8 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-07-23-eslint-1.0.0-rc-2-released.md
+++ b/_posts/2015-07-23-eslint-1.0.0-rc-2-released.md
@@ -7,8 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-07-24-eslint-1.0.0-rc-3-released.md
+++ b/_posts/2015-07-24-eslint-1.0.0-rc-3-released.md
@@ -7,9 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - IanVS
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-07-31-eslint-1.0.0-released.md
+++ b/_posts/2015-07-31-eslint-1.0.0-released.md
@@ -8,8 +8,6 @@ tags:
   - breaking change
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-08-07-eslint-1.1.0-released.md
+++ b/_posts/2015-08-07-eslint-1.1.0-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-08-18-eslint-1.2.0-released.md
+++ b/_posts/2015-08-18-eslint-1.2.0-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-08-20-eslint-1.2.1-released.md
+++ b/_posts/2015-08-20-eslint-1.2.1-released.md
@@ -7,7 +7,6 @@ tags:
   - release
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-08-28-eslint-v1.3.0-released.md
+++ b/_posts/2015-08-28-eslint-v1.3.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-08-29-eslint-v1.3.1-released.md
+++ b/_posts/2015-08-29-eslint-v1.3.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-09-11-eslint-v1.4.0-released.md
+++ b/_posts/2015-09-11-eslint-v1.4.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-09-11-eslint-v1.4.1-released.md
+++ b/_posts/2015-09-11-eslint-v1.4.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-09-15-eslint-v1.4.2-released.md
+++ b/_posts/2015-09-15-eslint-v1.4.2-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-09-15-eslint-v1.4.3-released.md
+++ b/_posts/2015-09-15-eslint-v1.4.3-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-09-18-eslint-v1.5.0-released.md
+++ b/_posts/2015-09-18-eslint-v1.5.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-09-22-eslint-v1.5.1-released.md
+++ b/_posts/2015-09-22-eslint-v1.5.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-10-02-eslint-v1.6.0-released.md
+++ b/_posts/2015-10-02-eslint-v1.6.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-10-16-eslint-v1.7.0-released.md
+++ b/_posts/2015-10-16-eslint-v1.7.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-10-16-eslint-v1.7.1-released.md
+++ b/_posts/2015-10-16-eslint-v1.7.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-10-19-eslint-v1.7.2-released.md
+++ b/_posts/2015-10-19-eslint-v1.7.2-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-10-21-eslint-v1.7.3-released.md
+++ b/_posts/2015-10-21-eslint-v1.7.3-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-10-30-eslint-v1.8.0-released.md
+++ b/_posts/2015-10-30-eslint-v1.8.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-11-06-eslint-v1.9.0-released.md
+++ b/_posts/2015-11-06-eslint-v1.9.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-11-20-eslint-v1.10.0-released.md
+++ b/_posts/2015-11-20-eslint-v1.10.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-11-20-eslint-v1.10.1-released.md
+++ b/_posts/2015-11-20-eslint-v1.10.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-11-27-eslint-v1.10.2-released.md
+++ b/_posts/2015-11-27-eslint-v1.10.2-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-12-01-eslint-v1.10.3-released.md
+++ b/_posts/2015-12-01-eslint-v1.10.3-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-12-01-espree-3-alpha-1-released.md
+++ b/_posts/2015-12-01-espree-3-alpha-1-released.md
@@ -9,7 +9,6 @@ tags:
   - alpha
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-12-09-espree-3-alpha-2-released.md
+++ b/_posts/2015-12-09-espree-3-alpha-2-released.md
@@ -9,7 +9,6 @@ tags:
   - alpha
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-12-11-eslint-v2.0.0-alpha-1-released.md
+++ b/_posts/2015-12-11-eslint-v2.0.0-alpha-1-released.md
@@ -8,9 +8,6 @@ tags:
   - major
 authors:
   - nzakas
-  - mysticatea
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2015-12-23-eslint-v2.0.0-alpha-2-released.md
+++ b/_posts/2015-12-23-eslint-v2.0.0-alpha-2-released.md
@@ -8,9 +8,6 @@ tags:
   - major
 authors:
   - nzakas
-  - mysticatea
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-01-11-eslint-v2.0.0-beta.1-released.md
+++ b/_posts/2016-01-11-eslint-v2.0.0-beta.1-released.md
@@ -8,10 +8,6 @@ tags:
   - major
 authors:
   - nzakas
-  - mysticatea
-  - mjomble
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-01-22-eslint-v2.0.0-beta.2-released.md
+++ b/_posts/2016-01-22-eslint-v2.0.0-beta.2-released.md
@@ -8,9 +8,6 @@ tags:
   - major
 authors:
   - nzakas
-  - mysticatea
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-01-29-eslint-v2.0.0-beta.3-released.md
+++ b/_posts/2016-01-29-eslint-v2.0.0-beta.3-released.md
@@ -8,10 +8,6 @@ tags:
   - major
 authors:
   - nzakas
-  - IanVS
-  - mjomble
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-02-02-eslint-v2.0.0-rc.0-released.md
+++ b/_posts/2016-02-02-eslint-v2.0.0-rc.0-released.md
@@ -8,8 +8,6 @@ tags:
   - major
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-02-09-eslint-v2.0.0-rc.1-released.md
+++ b/_posts/2016-02-09-eslint-v2.0.0-rc.1-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-02-12-eslint-v2.0.0-released.md
+++ b/_posts/2016-02-12-eslint-v2.0.0-released.md
@@ -8,9 +8,6 @@ tags:
   - major
 authors:
   - nzakas
-  - mysticatea
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-02-15-eslint-v2.1.0-released.md
+++ b/_posts/2016-02-15-eslint-v2.1.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-02-19-eslint-v2.2.0-released.md
+++ b/_posts/2016-02-19-eslint-v2.2.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-03-04-eslint-v2.3.0-released.md
+++ b/_posts/2016-03-04-eslint-v2.3.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-03-11-eslint-v2.4.0-released.md
+++ b/_posts/2016-03-11-eslint-v2.4.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-03-25-eslint-v2.5.0-released.md
+++ b/_posts/2016-03-25-eslint-v2.5.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-03-28-eslint-v2.5.3-released.md
+++ b/_posts/2016-03-28-eslint-v2.5.3-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-03-30-updated-rule-policy.md
+++ b/_posts/2016-03-30-updated-rule-policy.md
@@ -7,8 +7,6 @@ tags:
   - rules
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Policy Updates
 ---

--- a/_posts/2016-04-01-eslint-v2.6.0-released.md
+++ b/_posts/2016-04-01-eslint-v2.6.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-04-04-eslint-v2.7.0-released.md
+++ b/_posts/2016-04-04-eslint-v2.7.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-04-14-welcoming-jscs-to-eslint.md
+++ b/_posts/2016-04-14-welcoming-jscs-to-eslint.md
@@ -9,10 +9,6 @@ tags:
   - plans
 authors:
   - nzakas
-  - hzoo
-  - not-an-aardvark
-  - bytesnz
-  - kaicataldo
 categories:
   - Announcements
 ---

--- a/_posts/2016-04-15-eslint-v2.8.0-released.md
+++ b/_posts/2016-04-15-eslint-v2.8.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-04-19-eslint-joins-the-jquery-foundation.md
+++ b/_posts/2016-04-19-eslint-joins-the-jquery-foundation.md
@@ -8,7 +8,6 @@ tags:
   - Open Source
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Announcements
 ---

--- a/_posts/2016-04-29-eslint-v2.9.0-released.md
+++ b/_posts/2016-04-29-eslint-v2.9.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-05-13-eslint-v2.10.0-released.md
+++ b/_posts/2016-05-13-eslint-v2.10.0-released.md
@@ -8,10 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - mysticatea
-  - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-05-14-eslint-v2.10.1-released.md
+++ b/_posts/2016-05-14-eslint-v2.10.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-05-16-eslint-v2.10.2-released.md
+++ b/_posts/2016-05-16-eslint-v2.10.2-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-05-27-eslint-v2.11.0-released.md
+++ b/_posts/2016-05-27-eslint-v2.11.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-05-30-eslint-v2.11.1-released.md
+++ b/_posts/2016-05-30-eslint-v2.11.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-06-10-eslint-v2.12.0-released.md
+++ b/_posts/2016-06-10-eslint-v2.12.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-06-17-eslint-v2.13.0-released.md
+++ b/_posts/2016-06-17-eslint-v2.13.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-06-20-eslint-v2.13.1-released.md
+++ b/_posts/2016-06-20-eslint-v2.13.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-07-01-eslint-new-rule-format.md
+++ b/_posts/2016-07-01-eslint-new-rule-format.md
@@ -7,8 +7,6 @@ tags:
   - development
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - API Changes
 ---

--- a/_posts/2016-07-01-eslint-v3.0.0-released.md
+++ b/_posts/2016-07-01-eslint-v3.0.0-released.md
@@ -8,7 +8,6 @@ tags:
   - major
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-07-05-eslint-v3.0.1-released.md
+++ b/_posts/2016-07-05-eslint-v3.0.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-07-15-eslint-v3.1.0-released.md
+++ b/_posts/2016-07-15-eslint-v3.1.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-07-15-jscs-end-of-life.md
+++ b/_posts/2016-07-15-jscs-end-of-life.md
@@ -7,8 +7,6 @@ tags:
   - end of life
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Announcements
 ---

--- a/_posts/2016-07-18-eslint-v3.1.1-released.md
+++ b/_posts/2016-07-18-eslint-v3.1.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-07-29-eslint-v3.2.0-released.md
+++ b/_posts/2016-07-29-eslint-v3.2.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-08-01-eslint-v3.2.1-released.md
+++ b/_posts/2016-08-01-eslint-v3.2.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-08-01-eslint-v3.2.2-released.md
+++ b/_posts/2016-08-01-eslint-v3.2.2-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-08-12-eslint-v3.3.0-released.md
+++ b/_posts/2016-08-12-eslint-v3.3.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
-  - not-an-aardvark
 categories:
   - Release Notes
 ---

--- a/_posts/2016-08-26-eslint-v3.4.0-released.md
+++ b/_posts/2016-08-26-eslint-v3.4.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-09-09-eslint-v3.5.0-released.md
+++ b/_posts/2016-09-09-eslint-v3.5.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-09-15-changes-to-issues-and-pr-policies.md
+++ b/_posts/2016-09-15-changes-to-issues-and-pr-policies.md
@@ -7,7 +7,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Policy Updates
 ---

--- a/_posts/2016-09-23-eslint-v3.6.0-released.md
+++ b/_posts/2016-09-23-eslint-v3.6.0-released.md
@@ -8,12 +8,6 @@ tags:
   - minor
 authors:
   - gyandeeps
-  - not-an-aardvark
-  - ilyavolodin
-  - mysticatea
-  - balupton
-  - vitorbal
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-09-30-eslint-v3.7.0-released.md
+++ b/_posts/2016-09-30-eslint-v3.7.0-released.md
@@ -8,9 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - wdhorton
-  - platinumazure
-  - not-an-aardvark
 categories:
   - Release Notes
 ---

--- a/_posts/2016-10-14-eslint-v3.8.0-released.md
+++ b/_posts/2016-10-14-eslint-v3.8.0-released.md
@@ -8,9 +8,6 @@ tags:
   - minor
 authors:
   - mysticatea
-  - nzakas
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-10-28-eslint-v3.9.0-released.md
+++ b/_posts/2016-10-28-eslint-v3.9.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - ilyavolodin
-  - not-an-aardvark
 categories:
   - Release Notes
 ---

--- a/_posts/2016-11-11-eslint-v3.10.0-released.md
+++ b/_posts/2016-11-11-eslint-v3.10.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-11-25-eslint-v3.11.0-released.md
+++ b/_posts/2016-11-25-eslint-v3.11.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-11-28-eslint-v3.11.1-released.md
+++ b/_posts/2016-11-28-eslint-v3.11.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - btmills
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2016-12-09-eslint-v3.12.0-released.md
+++ b/_posts/2016-12-09-eslint-v3.12.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - btmills
 categories:
   - Release Notes
 ---

--- a/_posts/2017-01-06-eslint-v3.13.0-released.md
+++ b/_posts/2017-01-06-eslint-v3.13.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - gyandeeps
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-01-20-eslint-v3.14.0-released.md
+++ b/_posts/2017-01-20-eslint-v3.14.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-02-03-eslint-v3.15.0-released.md
+++ b/_posts/2017-02-03-eslint-v3.15.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-02-20-eslint-v3.16.0-released.md
+++ b/_posts/2017-02-20-eslint-v3.16.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - not-an-aardvark
 categories:
   - Release Notes
 ---

--- a/_posts/2017-03-03-eslint-v3.17.0-released.md
+++ b/_posts/2017-03-03-eslint-v3.17.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-03-17-eslint-v3.18.0-released.md
+++ b/_posts/2017-03-17-eslint-v3.18.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-03-31-eslint-v3.19.0-released.md
+++ b/_posts/2017-03-31-eslint-v3.19.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-04-07-eslint-v4.0.0-alpha.0-released.md
+++ b/_posts/2017-04-07-eslint-v4.0.0-alpha.0-released.md
@@ -8,8 +8,6 @@ tags:
   - major
 authors:
   - ilyavolodin
-  - kaicataldo
-  - pauljmartinez
 categories:
   - Release Notes
 ---

--- a/_posts/2017-04-21-eslint-v4.0.0-alpha.1-released.md
+++ b/_posts/2017-04-21-eslint-v4.0.0-alpha.1-released.md
@@ -8,9 +8,6 @@ tags:
   - major
 authors:
   - not-an-aardvark
-  - kaicataldo
-  - arzyu
-  - btmills
 categories:
   - Release Notes
 ---

--- a/_posts/2017-05-05-eslint-v4.0.0-alpha.2-released.md
+++ b/_posts/2017-05-05-eslint-v4.0.0-alpha.2-released.md
@@ -8,7 +8,6 @@ tags:
   - major
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-05-19-eslint-v4.0.0-beta.0-released.md
+++ b/_posts/2017-05-19-eslint-v4.0.0-beta.0-released.md
@@ -8,7 +8,6 @@ tags:
   - major
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-06-02-eslint-v4.0.0-rc.0-released.md
+++ b/_posts/2017-06-02-eslint-v4.0.0-rc.0-released.md
@@ -8,8 +8,6 @@ tags:
   - major
 authors:
   - btmills
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-06-11-eslint-v4.0.0-released.md
+++ b/_posts/2017-06-11-eslint-v4.0.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-06-23-eslint-v4.1.0-released.md
+++ b/_posts/2017-06-23-eslint-v4.1.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-07-08-eslint-v4.2.0-released.md
+++ b/_posts/2017-07-08-eslint-v4.2.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-08-07-eslint-v4.4.1-released.md
+++ b/_posts/2017-08-07-eslint-v4.4.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - kaicataldo
-  - not-an-aardvark
 categories:
   - Release Notes
 ---

--- a/_posts/2017-08-18-eslint-v4.5.0-released.md
+++ b/_posts/2017-08-18-eslint-v4.5.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-09-01-eslint-v4.6.0-released.md
+++ b/_posts/2017-09-01-eslint-v4.6.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-09-15-eslint-v4.7.0-released.md
+++ b/_posts/2017-09-15-eslint-v4.7.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-09-29-eslint-v4.8.0-released.md
+++ b/_posts/2017-09-29-eslint-v4.8.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - btmills
 categories:
   - Release Notes
 ---

--- a/_posts/2017-10-14-eslint-v4.9.0-released.md
+++ b/_posts/2017-10-14-eslint-v4.9.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-10-27-eslint-v4.10.0-released.md
+++ b/_posts/2017-10-27-eslint-v4.10.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-11-25-eslint-v4.12.0-released.md
+++ b/_posts/2017-11-25-eslint-v4.12.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - platinumazure
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-11-30-eslint-v4.12.1-released.md
+++ b/_posts/2017-11-30-eslint-v4.12.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-12-08-eslint-v4.13.0-released.md
+++ b/_posts/2017-12-08-eslint-v4.13.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2017-12-23-eslint-v4.14.0-released.md
+++ b/_posts/2017-12-23-eslint-v4.14.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-01-06-eslint-v4.15.0-released.md
+++ b/_posts/2018-01-06-eslint-v4.15.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - platinumazure
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-01-19-eslint-v4.16.0-released.md
+++ b/_posts/2018-01-19-eslint-v4.16.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-02-02-eslint-v4.17.0-released.md
+++ b/_posts/2018-02-02-eslint-v4.17.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-03-16-eslint-v4.19.0-released.md
+++ b/_posts/2018-03-16-eslint-v4.19.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-03-30-eslint-v5.0.0-alpha.0-released.md
+++ b/_posts/2018-03-30-eslint-v5.0.0-alpha.0-released.md
@@ -8,8 +8,6 @@ tags:
   - major
 authors:
   - not-an-aardvark
-  - kaicataldo
-  - pauljmartinez
 categories:
   - Release Notes
 ---

--- a/_posts/2018-04-13-eslint-v5.0.0-alpha.1-released.md
+++ b/_posts/2018-04-13-eslint-v5.0.0-alpha.1-released.md
@@ -8,8 +8,6 @@ tags:
   - major
 authors:
   - btmills
-  - kaicataldo
-  - pauljmartinez
 categories:
   - Release Notes
 ---

--- a/_posts/2018-04-27-eslint-v5.0.0-alpha.2-released.md
+++ b/_posts/2018-04-27-eslint-v5.0.0-alpha.2-released.md
@@ -8,7 +8,6 @@ tags:
   - major
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-05-11-eslint-v5.0.0-alpha.3-released.md
+++ b/_posts/2018-05-11-eslint-v5.0.0-alpha.3-released.md
@@ -8,8 +8,6 @@ tags:
   - major
 authors:
   - not-an-aardvark
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-05-28-eslint-v5.0.0-alpha.4-released.md
+++ b/_posts/2018-05-28-eslint-v5.0.0-alpha.4-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - kaicataldo
-  - pauljmartinez
 categories:
   - Release Notes
 ---

--- a/_posts/2018-06-09-eslint-v5.0.0-rc.0-released.md
+++ b/_posts/2018-06-09-eslint-v5.0.0-rc.0-released.md
@@ -8,9 +8,6 @@ tags:
   - minor
 authors:
   - platinumazure
-  - kaicataldo
-  - btmills
-  - pauljmartinez
 categories:
   - Release Notes
 ---

--- a/_posts/2018-06-22-eslint-v5.0.0-released.md
+++ b/_posts/2018-06-22-eslint-v5.0.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-07-08-eslint-v5.1.0-released.md
+++ b/_posts/2018-07-08-eslint-v5.1.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-07-12-postmortem-for-malicious-package-publishes.md
+++ b/_posts/2018-07-12-postmortem-for-malicious-package-publishes.md
@@ -6,8 +6,6 @@ tags:
   - security
 authors:
   - hzoo
-  - btmills
-  - kaicataldo
 categories:
   - Postmortems
 ---

--- a/_posts/2018-07-20-eslint-v5.2.0-released.md
+++ b/_posts/2018-07-20-eslint-v5.2.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-08-03-eslint-v5.3.0-released.md
+++ b/_posts/2018-08-03-eslint-v5.3.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-10-12-eslint-v5.7.0-released.md
+++ b/_posts/2018-10-12-eslint-v5.7.0-released.md
@@ -8,9 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - mysticatea
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-10-26-eslint-v5.8.0-released.md
+++ b/_posts/2018-10-26-eslint-v5.8.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-11-09-eslint-v5.9.0-released.md
+++ b/_posts/2018-11-09-eslint-v5.9.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-11-27-jsdoc-end-of-life.md
+++ b/_posts/2018-11-27-jsdoc-end-of-life.md
@@ -8,9 +8,6 @@ tags:
   - doctrine
 authors:
   - nzakas
-  - kaicataldo
-  - mysticatea
-  - not-an-aardvark
 categories:
   - Announcements
 ---

--- a/_posts/2018-12-08-eslint-v5.10.0-released.md
+++ b/_posts/2018-12-08-eslint-v5.10.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - platinumazure
-  - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2018-12-22-eslint-v5.11.0-released.md
+++ b/_posts/2018-12-22-eslint-v5.11.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-01-04-eslint-v5.12.0-released.md
+++ b/_posts/2019-01-04-eslint-v5.12.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-02-01-eslint-v5.13.0-released.md
+++ b/_posts/2019-02-01-eslint-v5.13.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-02-12-funding-eslint-future.md
+++ b/_posts/2019-02-12-funding-eslint-future.md
@@ -10,8 +10,6 @@ tags:
   - Backers
 authors:
   - nzakas
-  - kaicataldo
-  - Munter
 categories:
   - Sponsorships
 ---

--- a/_posts/2019-02-15-eslint-v5.14.0-released.md
+++ b/_posts/2019-02-15-eslint-v5.14.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-03-01-eslint-v5.15.0-released.md
+++ b/_posts/2019-03-01-eslint-v5.15.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-03-04-eslint-v5.15.1-released.md
+++ b/_posts/2019-03-04-eslint-v5.15.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - not-an-aardvark
-  - platinumazure
 categories:
   - Release Notes
 ---

--- a/_posts/2019-03-29-eslint-v5.16.0-released.md
+++ b/_posts/2019-03-29-eslint-v5.16.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - platinumazure
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-04-12-eslint-v6.0.0-alpha.0-released.md
+++ b/_posts/2019-04-12-eslint-v6.0.0-alpha.0-released.md
@@ -8,7 +8,6 @@ tags:
   - major
 authors:
   - not-an-aardvark
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-05-01-funding-update.md
+++ b/_posts/2019-05-01-funding-update.md
@@ -10,7 +10,6 @@ tags:
   - Backers
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Sponsorships
 ---

--- a/_posts/2019-05-10-eslint-v6.0.0-alpha.1-released.md
+++ b/_posts/2019-05-10-eslint-v6.0.0-alpha.1-released.md
@@ -8,8 +8,6 @@ tags:
   - major
 authors:
   - not-an-aardvark
-  - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-06-09-eslint-v6.0.0-rc.0-released.md
+++ b/_posts/2019-06-09-eslint-v6.0.0-rc.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - mysticatea
-  - platinumazure
 categories:
   - Release Notes
 ---

--- a/_posts/2019-06-21-eslint-v6.0.0-released.md
+++ b/_posts/2019-06-21-eslint-v6.0.0-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - kaicataldo
-  - not-an-aardvark
 categories:
   - Release Notes
 ---

--- a/_posts/2019-07-20-eslint-v6.1.0-released.md
+++ b/_posts/2019-07-20-eslint-v6.1.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - mysticatea
-  - platinumazure
 categories:
   - Release Notes
 ---

--- a/_posts/2019-08-18-eslint-v6.2.0-released.md
+++ b/_posts/2019-08-18-eslint-v6.2.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - mysticatea
-  - platinumazure
 categories:
   - Release Notes
 ---

--- a/_posts/2019-08-20-eslint-v6.2.1-released.md
+++ b/_posts/2019-08-20-eslint-v6.2.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - kaicataldo
-  - mysticatea
 categories:
   - Release Notes
 ---

--- a/_posts/2019-08-30-eslint-v6.3.0-released.md
+++ b/_posts/2019-08-30-eslint-v6.3.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-09-13-eslint-v6.4.0-released.md
+++ b/_posts/2019-09-13-eslint-v6.4.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - ilyavolodin
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2019-09-29-eslint-v6.5.0-released.md
+++ b/_posts/2019-09-29-eslint-v6.5.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - platinumazure
 categories:
   - Release Notes
 ---

--- a/_posts/2019-09-30-eslint-v6.5.1-released.md
+++ b/_posts/2019-09-30-eslint-v6.5.1-released.md
@@ -8,7 +8,6 @@ tags:
   - patch
 authors:
   - mysticatea
-  - platinumazure
 categories:
   - Release Notes
 ---

--- a/_posts/2019-10-25-eslint-v6.6.0-released.md
+++ b/_posts/2019-10-25-eslint-v6.6.0-released.md
@@ -8,8 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - kaicataldo
-  - platinumazure
 categories:
   - Release Notes
 ---

--- a/_posts/2019-11-07-funding-update.md
+++ b/_posts/2019-11-07-funding-update.md
@@ -10,7 +10,6 @@ tags:
   - Backers
 authors:
   - kaicataldo
-  - nzakas
 categories:
   - Financials
 ---

--- a/_posts/2019-11-22-eslint-v6.7.0-released.md
+++ b/_posts/2019-11-22-eslint-v6.7.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - kaicataldo
-  - mysticatea
 categories:
   - Release Notes
 ---

--- a/_posts/2019-12-20-eslint-v6.8.0-released.md
+++ b/_posts/2019-12-20-eslint-v6.8.0-released.md
@@ -8,7 +8,6 @@ tags:
   - minor
 authors:
   - btmills
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2020-01-17-eslint-v7.0.0-alpha.0-released.md
+++ b/_posts/2020-01-17-eslint-v7.0.0-alpha.0-released.md
@@ -8,7 +8,6 @@ tags:
   - major
 authors:
   - btmills
-  - kaicataldo
 categories:
   - Release Notes
 ---

--- a/_posts/2020-05-22-changes-to-rules-policies.md
+++ b/_posts/2020-05-22-changes-to-rules-policies.md
@@ -7,7 +7,6 @@ tags:
   - policies
 authors:
   - nzakas
-  - btmills
 categories:
   - Policy Updates
 ---

--- a/_posts/2020-08-06-salesforce-donates-10000-to-eslint.md
+++ b/_posts/2020-08-06-salesforce-donates-10000-to-eslint.md
@@ -10,7 +10,6 @@ tags:
   - Backers
 authors:
   - nzakas
-  - mdjermanovic
 categories: 
   - Sponsorships
 ---

--- a/_posts/2020-08-10-making-eslint-more-inclusive.md
+++ b/_posts/2020-08-10-making-eslint-more-inclusive.md
@@ -8,7 +8,6 @@ tags:
   - Code of Conduct
 authors:
   - nzakas
-  - kaicataldo
 categories:
   - Announcements
 ---


### PR DESCRIPTION
On blog posts with more than 1 author listed, all authors except the first one have been removed.

Fixes #918