### PR TITLE
fix: check if blog post authors are specified in fetch-team-data script

### DIFF
--- a/_posts/2022-03-25-eslint-v8.12.0-released.md
+++ b/_posts/2022-03-25-eslint-v8.12.0-released.md
@@ -3,6 +3,8 @@ layout: post
 title: ESLint v8.12.0 released
 teaser: "We just pushed ESLint v8.12.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
 image: release-notes-minor.png
+authors:
+  - btmills
 categories:
   - Release Notes
 tags:

--- a/_tools/fetch-team-data.js
+++ b/_tools/fetch-team-data.js
@@ -145,8 +145,10 @@ async function fetchBlogAuthors() {
         const contents = await fs.readFile(filename, "utf8");
         const { data: frontmatter } = matter(contents);
 
-        for (const username of frontmatter.authors) {
-            authors[username] = await fetchUserProfile(username);
+        if (Array.isArray(frontmatter.authors)) {
+            for (const username of frontmatter.authors) {
+                authors[username] = await fetchUserProfile(username);
+            }
         }
     }
 


### PR DESCRIPTION
The fetch-team-data.js script is failing with the following error:

```
TypeError: frontmatter.authors is not iterable
```

(check on Jenkins)

I updated one blog post that didn't have `authors`, but that alone doesn't help because we're running the fetch script right after the release, and at that point there's a newly created release post without authors. Therefore, I also updated the script to check if `authors` exists.

I tested this locally and it works well, but I didn't commit the change in `team.json` so that the Jenkins job could update the team info both on the website and the README.md in eslint/eslint after the next release.
