### PR TITLE
chore: Update rule docs format

### DIFF
--- a/_layouts/doc.liquid
+++ b/_layouts/doc.liquid
@@ -23,7 +23,7 @@
       <h1>{{ title }}</h1>
       {% endunless %}
 
-      {{ content
+      {% assign all_content = content
         | replace: '<p>Examples of <strong>incorrect</strong> code', '<p class="incorrect icon">Examples of <strong>incorrect</strong> code'
         | replace: '<p>Example of <strong>incorrect</strong> code', '<p class="incorrect icon">Example of <strong>incorrect</strong> code'
         | replace: '<p>Examples of additional <strong>incorrect</strong> code', '<p class="incorrect icon">Examples of additional <strong>incorrect</strong> code'
@@ -39,7 +39,37 @@
         | replace: '(recommended)', '<span title="recommended" aria-label="recommended">✓</span>'
         | replace: '(fixable)', '<span title="fixable" aria-label="fixable">🔧</span>'
         | replace: '(hasSuggestions)', '<span title="hasSuggestions" aria-label="hasSuggestions">💡</span>'
-      }}
+      %}
+
+      {% if related_rules %}
+        {% capture related_rules_content %}
+        <h2 id="related-rules">Related Rules</h2>
+        <ul>
+          {% for rule_id in related_rules %}
+          <li><a href="{{ rule_id }}">{{ rule_id }}</a></li>
+          {% endfor %}
+        </ul>
+        <h2 id="version">Version</h2>
+        {% endcapture %}
+        {% assign all_content = all_content | replace: '<h2 id="version">Version</h2>', related_rules_content %}
+      {% endif %}
+
+      {% if further_reading %}
+        {% capture further_reading_content %}
+        <h2 id="further-reading">Further Reading</h2>
+        <ul>
+          {% for url in further_reading %}
+          <li><a href="{{ url }}">{{ url }}</a></li>
+          {% endfor %}
+        </ul>
+        <h2 id="version">Version</h2>
+
+        {% endcapture %}
+        {% assign all_content = all_content | replace: '<h2 id="version">Version</h2>', further_reading_content %}
+      {% endif %}
+
+      {{ all_content }}
+
     </article>
   </main>
   {% include footer %}

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -3,6 +3,9 @@ title: block-scoped-var
 layout: doc
 edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/block-scoped-var.md
 rule_type: suggestion
+further_reading:
+- https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html
+- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting
 ---
 
 Enforces treating `var` as block scoped.
@@ -111,11 +114,6 @@ class C {
     }
 }
 ```
-
-## Further Reading
-
-* [JavaScript Scoping and Hoisting](http://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html)
-* [var Hoisting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting)
 
 ## Version
 

--- a/docs/rules/no-ternary.md
+++ b/docs/rules/no-ternary.md
@@ -3,6 +3,9 @@ title: no-ternary
 layout: doc
 edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-ternary.md
 rule_type: suggestion
+related_rules:
+- no-nested-ternary
+- no-unneeded-ternary
 ---
 
 Disallows ternary operators.
@@ -50,11 +53,6 @@ function quux() {
     }
 }
 ```
-
-## Related Rules
-
-* [no-nested-ternary](no-nested-ternary)
-* [no-unneeded-ternary](no-unneeded-ternary)
 
 ## Version
 


### PR DESCRIPTION
Updated the current website documentation page format to accept the new frontmatter introduced in https://github.com/eslint/eslint/pull/15869.