### PR TITLE
docs: remove duplicate text

### DIFF
--- a/_pages/users.liquid
+++ b/_pages/users.liquid
@@ -4,7 +4,6 @@ layout: doc
 ad: text
 ---
 
-<h1>Who's Using ESLint?</h1>
 <p>These are the companies and organizations who use ESLint to keep their JavaScript code lint-free!</p>
 <div class="logos row">
     {% for logo in logos %}


### PR DESCRIPTION
Description:
Removed duplicate heading from eslint users (https://eslint.org/users) page.