### PR TITLE
docs: remove duplicate text

### DIFF
--- a/_pages/team.liquid
+++ b/_pages/team.liquid
@@ -4,7 +4,6 @@ layout: doc
 ad: text
 ---
 
-<h1>Team</h1>
 <p>These are the people who build and maintain ESLint.</p>
 <h2>Technical Steering Committee</h2>
 <p>The people who manage releases, review feature requests, and meet regularly to ensure ESLint is properly maintained.</p>


### PR DESCRIPTION
Description:
Removed duplicate heading from eslint Team (https://eslint.org/team) page.