### PR TITLE
fix: removes layout shift caused due to ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm install
 Once you have set up your environment, you can run a copy of the website locally using this command:
 
 ```sh
-$ npm start
+npm start
 ```
 
 This will watch for changes to the source code and rebuild the website, which will be hosted at `http://localhost:8080/`.

--- a/src/styles/lib/ad.less
+++ b/src/styles/lib/ad.less
@@ -51,11 +51,15 @@
 }
 
 .eslint-ad-float {
+    width: 200px;
+    height: 250px;
     float: right;
     margin: 2.5rem 0 2.5rem 1.5rem;
 }
 
 .eslint-ad-float-left {
+    height: 250px;
+    width: 200px;
     float: left;
     margin: 2.5rem 0;
 }


### PR DESCRIPTION
The ads don't have proper height and width so it causes the content to shift from left to right and top to bottom in different pages. So we give explicit height for the ad banners to avoid those shifts


https://user-images.githubusercontent.com/32865581/169266152-65e498bb-6287-4161-aca7-f6f8708a8bb9.mov


https://user-images.githubusercontent.com/32865581/169265443-3f28d8f7-a73f-4ddf-ba2f-5bf055a9903f.mov


https://user-images.githubusercontent.com/32865581/169265457-0fb12361-c2c8-43e2-8c97-937168fe4220.mov

