### PR TITLE
chore: Enable containers

### DIFF
--- a/_11ty/plugins/markdown-plugins.js
+++ b/_11ty/plugins/markdown-plugins.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const markdownIt = require("markdown-it");
+const markdownItContainer = require("markdown-it-container");
 const highlightJS = require("highlight.js");
 const { slug } = require("github-slugger");
 
@@ -37,6 +38,11 @@ module.exports = function syntaxHighlighting(eleventyConfig) {
         },
         uniqueSlugStartIndex: 1
     });
+
+    // add markdown containers
+    md = md
+        .use(require("markdown-it-container"), "correct", {})
+        .use(require("markdown-it-container"), "incorrect", {});
 
     eleventyConfig.setLibrary("md", md);
 };

--- a/_11ty/plugins/markdown-plugins.js
+++ b/_11ty/plugins/markdown-plugins.js
@@ -41,8 +41,8 @@ module.exports = function syntaxHighlighting(eleventyConfig) {
 
     // add markdown containers
     md = md
-        .use(require("markdown-it-container"), "correct", {})
-        .use(require("markdown-it-container"), "incorrect", {});
+        .use(markdownItContainer, "correct", {})
+        .use(markdownItContainer, "incorrect", {});
 
     eleventyConfig.setLibrary("md", md);
 };

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -12,8 +12,6 @@ further_reading:
 - https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons
 ---
 
-
-
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Requires or disallows semicolons instead of ASI.
@@ -100,6 +98,8 @@ Object option (when `"never"`):
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint semi: ["error", "always"]*/
 
@@ -114,7 +114,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint semi: "error"*/
@@ -130,9 +134,13 @@ class Foo {
 }
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint semi: ["error", "never"]*/
@@ -148,7 +156,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint semi: ["error", "never"]*/
@@ -180,9 +192,13 @@ class Foo {
 }
 ```
 
+:::
+
 #### omitLastInOneLineBlock
 
 Examples of additional **correct** code for this rule with the `"always", { "omitLastInOneLineBlock": true }` options:
+
+::: correct
 
 ```js
 /*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
@@ -200,9 +216,13 @@ class C {
 }
 ```
 
+:::
+
 #### beforeStatementContinuationChars
 
 Examples of additional **incorrect** code for this rule with the `"never", { "beforeStatementContinuationChars": "always" }` options:
+
+::: incorrect
 
 ```js
 /*eslint semi: ["error", "never", { "beforeStatementContinuationChars": "always"}] */
@@ -213,7 +233,11 @@ import a from "a"
 })()
 ```
 
+:::
+
 Examples of additional **incorrect** code for this rule with the `"never", { "beforeStatementContinuationChars": "never" }` options:
+
+::: incorrect
 
 ```js
 /*eslint semi: ["error", "never", { "beforeStatementContinuationChars": "never"}] */
@@ -224,16 +248,8 @@ import a from "a"
 })()
 ```
 
+:::
+
 ## When Not To Use It
 
 If you do not want to enforce semicolon usage (or omission) in any particular way, then you can turn this rule off.
-
-## Version
-
-This rule was introduced in ESLint 0.0.6.
-
-## Resources
-
-* [Rule source](https://github.com/eslint/eslint/tree/HEAD/lib/rules/semi.js)
-* [Test source](https://github.com/eslint/eslint/tree/HEAD/tests/lib/rules/semi.js)
-* [Documentation source](https://github.com/eslint/eslint/tree/HEAD/docs/src/rules/semi.md)

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -12,6 +12,8 @@ further_reading:
 - https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons
 ---
 
+
+
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Requires or disallows semicolons instead of ASI.
@@ -253,3 +255,13 @@ import a from "a"
 ## When Not To Use It
 
 If you do not want to enforce semicolon usage (or omission) in any particular way, then you can turn this rule off.
+
+## Version
+
+This rule was introduced in ESLint 0.0.6.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/HEAD/lib/rules/semi.js)
+* [Test source](https://github.com/eslint/eslint/tree/HEAD/tests/lib/rules/semi.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/HEAD/docs/src/rules/semi.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "luxon": "^1.24.1",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^6.0.0",
+        "markdown-it-container": "^3.0.0",
         "morgan": "^1.10.0",
         "node-fetch": "^2.6.7",
         "node-polyfill-webpack-plugin": "^1.0.3",
@@ -7698,6 +7699,12 @@
       "peerDependencies": {
         "markdown-it": "*"
       }
+    },
+    "node_modules/markdown-it-container": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
+      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw==",
+      "dev": true
     },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
@@ -17566,6 +17573,12 @@
       "integrity": "sha512-8qX4r5R6AtXla9HKCouEQ40inw69O5jR4VUXlZySsBLxIXlsJ3Yi9JV6JWPU4ZdA8jWTGDDJjJYNLwQ0W4jCag==",
       "dev": true,
       "requires": {}
+    },
+    "markdown-it-container": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
+      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw==",
+      "dev": true
     },
     "maximatch": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "luxon": "^1.24.1",
     "markdown-it": "^12.3.2",
     "markdown-it-anchor": "^6.0.0",
+    "markdown-it-container": "^3.0.0",
     "morgan": "^1.10.0",
     "node-fetch": "^2.6.7",
     "node-polyfill-webpack-plugin": "^1.0.3",

--- a/src/styles/lib/overrides.less
+++ b/src/styles/lib/overrides.less
@@ -49,17 +49,6 @@ body {
 }
 
 p {
-  &.incorrect + div + div + div > pre, /* vars-on-top */
-  &.incorrect + div + div > pre, /* no-continue */
-  &.incorrect + div > pre {
-    background-color: #fff6f6; /* hsl(0,100%,98%) light red */
-  }
-
-  &.correct + div + div + div > pre, /* vars-on-top */
-  &.correct + div + div > pre, /* no-continue */
-  &.correct + div > pre {
-    background-color: #f6fff6; /* hsl(120,100%,98%) light green */
-  }
 
   &.icon {
     position:relative;


### PR DESCRIPTION
In order to use containers in the new docs site, we also need to enable them here, otherwise we will get the plain text artifacts of the containers showing up in the web pages.

This pull request:

1. Enables `correct` and `incorrect` containers in markdown
2. Updates the `semi.md` file as an example

Related pull request for new docs site:
https://github.com/eslint/eslint/pull/15998